### PR TITLE
Support background execution

### DIFF
--- a/android/src/main/java/com/eyedeadevelopers/fluttertts/FlutterTtsPlugin.java
+++ b/android/src/main/java/com/eyedeadevelopers/fluttertts/FlutterTtsPlugin.java
@@ -1,6 +1,7 @@
 package com.eyedeadevelopers.fluttertts;
 
 import android.app.Activity;
+import android.content.Context;
 import android.os.Bundle;
 import android.speech.tts.TextToSpeech;
 import android.speech.tts.UtteranceProgressListener;
@@ -24,12 +25,12 @@ public class FlutterTtsPlugin implements MethodCallHandler {
   Bundle bundle;
 
   /** Plugin registration. */
-  private FlutterTtsPlugin(Activity activity, MethodChannel channel) {
+  private FlutterTtsPlugin(Context context, MethodChannel channel) {
     this.channel = channel;
     this.channel.setMethodCallHandler(this);
 
     bundle = new Bundle();
-    tts = new TextToSpeech(activity.getApplicationContext(), onInitListener);
+    tts = new TextToSpeech(context.getApplicationContext(), onInitListener);
   };
 
   private UtteranceProgressListener utteranceProgressListener =
@@ -79,7 +80,7 @@ public class FlutterTtsPlugin implements MethodCallHandler {
 
   public static void registerWith(Registrar registrar) {
     final MethodChannel channel = new MethodChannel(registrar.messenger(), "flutter_tts");
-    channel.setMethodCallHandler(new FlutterTtsPlugin(registrar.activity(), channel));
+    channel.setMethodCallHandler(new FlutterTtsPlugin(registrar.activeContext(), channel));
   }
 
   @Override


### PR DESCRIPTION
Now that Flutter supports background execution, `registrar.activity()` will return null if running in a Service. I've changed this to `registrar.activeContext()` which will return the active context regardless of whether it is an Activity or a Service.