### PR TITLE
Add swift version to iOS podspec

### DIFF
--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -21,7 +21,7 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
     
     // Allow audio playback when the Ring/Silent switch is set to silent
     do {
-      try AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayback)
+      try AVAudioSession.sharedInstance().setCategory(.playback)
       try AVAudioSession.sharedInstance().setActive(true)
     } catch {
       print(error)

--- a/ios/flutter_tts.podspec
+++ b/ios/flutter_tts.podspec
@@ -16,6 +16,7 @@ A flutter text to speech plugin
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.ios.deployment_target = '8.0'
+  s.swift_version = '4.0'
   s.static_framework = true
 end
 

--- a/ios/flutter_tts.podspec
+++ b/ios/flutter_tts.podspec
@@ -16,7 +16,7 @@ A flutter text to speech plugin
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.ios.deployment_target = '8.0'
-  s.swift_version = '4.0'
+  s.swift_version = '4.2'
   s.static_framework = true
 end
 


### PR DESCRIPTION
Builds the iOS framework with the specified swift version

Fixes issue #25 when the main target is built with SWIFT_VERSION >= 4.2