### PR TITLE
Unified Speech Rate Value

### DIFF
--- a/android/src/main/java/com/tundralabs/fluttertts/FlutterTtsPlugin.java
+++ b/android/src/main/java/com/tundralabs/fluttertts/FlutterTtsPlugin.java
@@ -142,7 +142,8 @@ public class FlutterTtsPlugin implements MethodCallHandler {
     }
 
     void setSpeechRate(float rate) {
-        tts.setSpeechRate(rate);
+        float convertedRate = rate < 0.5f ? 0.25f + (0.5f * rate) + (2f * (rate * rate)) : 2f - (6f * rate) + (8f * (rate * rate));
+        tts.setSpeechRate(convertedRate);
     }
 
     Boolean isLanguageAvailable(Locale locale) {

--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -29,6 +29,7 @@ class FlutterTts {
   /// Allowed values are in the range from 0.0 (silent) to 1.0 (loudest)
   Future<dynamic> setSpeechRate(double rate) =>
       _channel.invokeMethod('setSpeechRate', rate);
+  /// Allowed values are in the range from 0.0 (slowest) to 1.0 (fastest)
 
   /// [Future] which invokes the platform specific method for setVolume
   /// Allowed values are in the range from 0.0 (silent) to 1.0 (loudest)


### PR DESCRIPTION
This solves issues like this: https://github.com/dlutton/flutter_tts/issues/30

Goal of the PR:
Use the same value for speechRate regardless if you are using iOS or Android.

Right now, the library uses the native speech rate for each platform.
In iOS the values should be from 0 to 1 whereas in android values should be from 0.25 to 4.
People don't realize that they must pass different values depending on the platform making the app behave in a different way than expected.

For simplicity sake I'm using the iOS scale as default: from 0 to 1.0 where 0 is the slowest possible speech rate and 1.0 is the fastest where 0.5 would be the normal speed.

Since on Android the speech rate follows this pattern: https://developer.android.com/reference/android/speech/tts/TextToSpeech.html#setSpeechRate(float) we can't really make the conversion in a single equation so I'm using two different square equations to make the conversion between iOS scale to Android scale, one for values under 0.5 and another for values over 0.5.

