### PR TITLE
Fix Android async platform initialization

### DIFF
--- a/android/src/main/java/com/tundralabs/fluttertts/FlutterTtsPlugin.java
+++ b/android/src/main/java/com/tundralabs/fluttertts/FlutterTtsPlugin.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -28,6 +29,7 @@ public class FlutterTtsPlugin implements MethodCallHandler {
     private final Handler handler;
     private final MethodChannel channel;
     private TextToSpeech tts;
+    private final CountDownLatch ttsInitLatch = new CountDownLatch(1);
     private final String tag = "TTS";
     private final String googleTtsEngine = "com.google.android.tts";
     String uuid;
@@ -79,6 +81,7 @@ public class FlutterTtsPlugin implements MethodCallHandler {
                 public void onInit(int status) {
                     if (status == TextToSpeech.SUCCESS) {
                         tts.setOnUtteranceProgressListener(utteranceProgressListener);
+                        ttsInitLatch.countDown();
                         invokeMethod("tts.init", true);
 
                         try {
@@ -102,6 +105,12 @@ public class FlutterTtsPlugin implements MethodCallHandler {
 
     @Override
     public void onMethodCall(MethodCall call, Result result) {
+        //Wait for TTS engine to be ready
+        try {
+            ttsInitLatch.await();
+        } catch (InterruptedException e){
+            throw new AssertionError("Unexpected Interruption", e);
+        }
         if (call.method.equals("speak")) {
             String text = call.arguments.toString();
             speak(text);


### PR DESCRIPTION
This is a fix for #73/#75.

I started out just wanting to simplify the API but discovered a race condition. Because the Android `TextToSpeech` engine initializes asynchronously at start up, it would sometimes send the `tts.init` message before the Flutter side had started listening to the channel.

So, to kill two birds with one stone, I've added a [`CountDownLatch`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CountDownLatch.html) which guarantees the engine is initialized before we start calling methods on it. This keeps the Flutter API super simple:

```dart
final flutterTts = FlutterTts();
//No need for init handlers or async/await
flutterTts.speak('Hello world!');
```

`ttsInitHandler()` remains as it was for backwards compatibility, but it still suffers from this race condition so should be removed.