### PR TITLE
Speech rate

### DIFF
--- a/android/src/main/java/com/tundralabs/fluttertts/FlutterTtsPlugin.java
+++ b/android/src/main/java/com/tundralabs/fluttertts/FlutterTtsPlugin.java
@@ -16,6 +16,7 @@ import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.UUID;
 
@@ -161,6 +162,8 @@ public class FlutterTtsPlugin implements MethodCallHandler {
       getLanguages(result);
     } else if (call.method.equals("getVoices")) {
       getVoices(result);
+    } else if (call.method.equals("getSpeechRateValidRange")) {
+      getSpeechRateValidRange(result);
     } else if (call.method.equals("setVoice")) {
       String voice = call.arguments.toString();
       setVoice(voice, result);
@@ -177,7 +180,7 @@ public class FlutterTtsPlugin implements MethodCallHandler {
   }
 
   void setSpeechRate(float rate) {
-    tts.setSpeechRate(rate * 2.0f);
+    tts.setSpeechRate(rate);
   }
 
   Boolean isLanguageAvailable(Locale locale) {
@@ -255,6 +258,16 @@ public class FlutterTtsPlugin implements MethodCallHandler {
       }
     }
     result.success(locales);
+  }
+
+  void getSpeechRateValidRange(Result result) {
+    // Valid values available in the android documentation.
+    // https://developer.android.com/reference/android/speech/tts/TextToSpeech#setSpeechRate(float)
+    final HashMap<String, String> limits = new HashMap<String, String>();
+    limits.put("min", "0");
+    limits.put("normal", "1");
+    limits.put("max", "3");
+    result.success(limits);
   }
 
   private void speak(String text) {

--- a/android/src/main/java/com/tundralabs/fluttertts/FlutterTtsPlugin.java
+++ b/android/src/main/java/com/tundralabs/fluttertts/FlutterTtsPlugin.java
@@ -263,11 +263,12 @@ public class FlutterTtsPlugin implements MethodCallHandler {
   void getSpeechRateValidRange(Result result) {
     // Valid values available in the android documentation.
     // https://developer.android.com/reference/android/speech/tts/TextToSpeech#setSpeechRate(float)
-    final HashMap<String, String> limits = new HashMap<String, String>();
-    limits.put("min", "0");
-    limits.put("normal", "1");
-    limits.put("max", "3");
-    result.success(limits);
+    final HashMap<String, String> data = new HashMap<String, String>();
+    data.put("min", "0");
+    data.put("normal", "1");
+    data.put("max", "3");
+    data.put("platform", "android");
+    result.success(data);
   }
 
   private void speak(String text) {

--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -71,6 +71,9 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
     case "getLanguages":
       self.getLanguages(result: result)
       break
+    case "getSpeechRateValidRange":
+      self.getSpeechRateValidRange(result: result)
+      break
     case "isLanguageAvailable":
       let language: String = call.arguments as! String
       self.isLanguageAvailable(language: language, result: result)
@@ -139,6 +142,16 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
 
   private func getLanguages(result: FlutterResult) {
     result(Array(self.languages))
+  }
+
+  private func getSpeechRateValidRange(result: FlutterResult) {
+    let validSpeechRateRange: [String:String] = [
+      "min": String(AVSpeechUtteranceMinimumSpeechRate),
+      "normal": String(AVSpeechUtteranceDefaultSpeechRate),
+      "max": String(AVSpeechUtteranceMaximumSpeechRate),
+      "platform": "ios"
+    ]
+    result(validSpeechRateRange)
   }
 
   private func isLanguageAvailable(language: String, result: FlutterResult) {

--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -5,6 +5,14 @@ import 'package:flutter/services.dart';
 
 typedef void ErrorHandler(dynamic message);
 
+class SpeechRateValidRange {
+  final double min;
+  final double normal;
+  final double max;
+
+  SpeechRateValidRange(this.min, this.normal, this.max);
+}
+
 // Provides Platform specific TTS services (Android: TextToSpeech, IOS: AVSpeechSynthesizer)
 class FlutterTts {
   static const MethodChannel _channel = const MethodChannel('flutter_tts');
@@ -74,6 +82,15 @@ class FlutterTts {
   /// Returns `true` or `false`
   Future<dynamic> isLanguageAvailable(String language) =>
       _channel.invokeMethod('isLanguageAvailable', language);
+
+  Future<SpeechRateValidRange> get getSpeechRateValidRange async {
+    final validRange = await _channel.invokeMethod('getSpeechRateValidRange')
+        as Map<dynamic, dynamic>;
+    final min = double.parse(validRange['min'].toString());
+    final normal = double.parse(validRange['normal'].toString());
+    final max = double.parse(validRange['max'].toString());
+    return SpeechRateValidRange(min, normal, max);
+  }
 
   /// [Future] which invokes the platform specific method for setSilence
   /// 0 means start the utterance immediately. If the value is greater than zero a silence period in milliseconds is set according to the parameter

--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -5,12 +5,15 @@ import 'package:flutter/services.dart';
 
 typedef void ErrorHandler(dynamic message);
 
+enum Platform { android, ios }
+
 class SpeechRateValidRange {
   final double min;
   final double normal;
   final double max;
+  final Platform platform;
 
-  SpeechRateValidRange(this.min, this.normal, this.max);
+  SpeechRateValidRange(this.min, this.normal, this.max, this.platform);
 }
 
 // Provides Platform specific TTS services (Android: TextToSpeech, IOS: AVSpeechSynthesizer)
@@ -89,7 +92,11 @@ class FlutterTts {
     final min = double.parse(validRange['min'].toString());
     final normal = double.parse(validRange['normal'].toString());
     final max = double.parse(validRange['max'].toString());
-    return SpeechRateValidRange(min, normal, max);
+    final platformStr = validRange['platform'].toString();
+    final platform =
+        Platform.values.firstWhere((e) => describeEnum(e) == platformStr);
+
+    return SpeechRateValidRange(min, normal, max, platform);
   }
 
   /// [Future] which invokes the platform specific method for setSilence


### PR DESCRIPTION
I made this before noticing the 2x multiplier in the android setSpeechRate (which is removed in this PR, breaking the API).

You dont have to merge this as the benefits are not something that everyone needs. But this will allow the consumer of the API to:
* Adjust your own rate modifier depending on the platform as adjusting the rate by 10% may not yield the same result on all platforms.
* Write code that does not need to change if the valid values for speech rate changes.

The difference in the API would be:
Today:
double rateModifier = 0.9;
tts.setSpeechRate(0.5 * rateModifier);

With this PR:
double rateModifier = 0.9;
final valid = await tts.getSpeechRateValidRange();
tts.setSpeechRate(valid.normal * rateModifier);