### PR TITLE
Fix set category ios

### DIFF
--- a/ios/Classes/AudioCategory.swift
+++ b/ios/Classes/AudioCategory.swift
@@ -1,0 +1,21 @@
+import AVFoundation
+
+enum AudioCategory: String {
+  case iosAudioCategoryAmbientSolo
+  case iosAudioCategoryAmbient
+  case iosAudioCategoryPlayback
+  case iosAudioCategoryPlaybackAndRecord
+  
+  func toAVAudioSessionCategory() -> AVAudioSession.Category {
+    switch self {
+    case .iosAudioCategoryAmbientSolo:
+      return .soloAmbient
+    case .iosAudioCategoryAmbient:
+      return .ambient
+    case .iosAudioCategoryPlayback:
+      return .playback
+    case .iosAudioCategoryPlaybackAndRecord:
+      return .playAndRecord
+    }
+  }
+}

--- a/ios/Classes/AudioCategoryOptions.swift
+++ b/ios/Classes/AudioCategoryOptions.swift
@@ -1,0 +1,42 @@
+import AVFoundation
+
+enum AudioCategoryOptions: String {
+  case iosAudioCategoryOptionsMixWithOthers
+  case iosAudioCategoryOptionsDuckOthers
+  case iosAudioCategoryOptionsInterruptSpokenAudioAndMixWithOthers
+  case iosAudioCategoryOptionsAllowBluetooth
+  case iosAudioCategoryOptionsAllowBluetoothA2DP
+  case iosAudioCategoryOptionsAllowAirPlay
+  case iosAudioCategoryOptionsDefaultToSpeaker
+  
+  func toAVAudioSessionCategoryOptions() -> AVAudioSession.CategoryOptions? {
+    switch self {
+    case .iosAudioCategoryOptionsMixWithOthers:
+      return .mixWithOthers
+    case .iosAudioCategoryOptionsDuckOthers:
+      return .duckOthers
+    case .iosAudioCategoryOptionsInterruptSpokenAudioAndMixWithOthers:
+      if #available(iOS 9.0, *) {
+        return .interruptSpokenAudioAndMixWithOthers
+      } else {
+        return nil
+      }
+    case .iosAudioCategoryOptionsAllowBluetooth:
+      return .allowBluetooth
+    case .iosAudioCategoryOptionsAllowBluetoothA2DP:
+      if #available(iOS 10.0, *) {
+        return .allowBluetoothA2DP
+      } else {
+        return nil
+      }
+    case .iosAudioCategoryOptionsAllowAirPlay:
+      if #available(iOS 10.0, *) {
+        return .allowAirPlay
+      } else {
+        return nil
+      }
+    case .iosAudioCategoryOptionsDefaultToSpeaker:
+      return .defaultToSpeaker
+    }
+  }
+}

--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -178,57 +178,21 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
           result(0)
       }
   }
-    private func setAudioCategory(audioCategory: String?, audioOptions: Array<String>?, result: FlutterResult){
-        do{
-            var category: AVAudioSession.Category = audioSession.category
-            var options: AVAudioSession.CategoryOptions = []
-            if(!(audioCategory?.isEmpty ?? true)){
-                if(audioCategory == "iosAudioCategoryAmbientSolo"){
-                    category = AVAudioSession.Category.soloAmbient
-                }
-                if(audioCategory == "iosAudioCategoryAmbient"){
-                    category = AVAudioSession.Category.ambient
-                }
-                if(audioCategory == "iosAudioCategoryPlayback"){
-                    category = AVAudioSession.Category.playback
-                }
-                if(audioCategory == "iosAudioCategoryPlaybackAndRecord"){
-                    category = AVAudioSession.Category.playAndRecord
-                }
-            }
-            if(!(audioOptions?.isEmpty ?? true)){
-                if(audioOptions!.contains("iosAudioCategoryOptionsMixWithOthers")){
-                    options.insert(AVAudioSession.CategoryOptions.mixWithOthers)
-                }
-                if(audioOptions!.contains("iosAudioCategoryOptionsDuckOthers")){
-                    options.insert(AVAudioSession.CategoryOptions.duckOthers);
-                }
-                if #available(iOS 9.0, *) {
-                    if(audioOptions!.contains("iosAudioCategoryOptionsInterruptSpokenAudioAndMixWithOthers")){
-                        options.insert(AVAudioSession.CategoryOptions.interruptSpokenAudioAndMixWithOthers)
-                    }
-                }
-                if(audioOptions!.contains("iosAudioCategoryOptionsAllowBluetooth")){
-                    options.insert(AVAudioSession.CategoryOptions.allowBluetooth)
-                }
-                if #available(iOS 10.0, *) {
-                    if(audioOptions!.contains("iosAudioCategoryOptionsAllowBluetoothA2DP")){
-                        options.insert(AVAudioSession.CategoryOptions.allowBluetoothA2DP)
-                    }
-                    if(audioOptions!.contains("iosAudioCategoryOptionsAllowAirPlay")){
-                        options.insert(AVAudioSession.CategoryOptions.allowAirPlay)
-                    }
-                }
-                if(audioOptions!.contains("iosAudioCategoryOptionsDefaultToSpeaker")){
-                    options.insert(AVAudioSession.CategoryOptions.defaultToSpeaker)
-                }
-            }
-            try audioSession.setCategory(category, options: options)
-        } catch {
-             print(error)
-        }
+  
+  private func setAudioCategory(audioCategory: String?, audioOptions: Array<String>?, result: FlutterResult){
+    let category: AVAudioSession.Category = AudioCategory(rawValue: audioCategory ?? "")?.toAVAudioSessionCategory() ?? audioSession.category
+    let options: AVAudioSession.CategoryOptions = audioOptions?.reduce([], { (result, option) -> AVAudioSession.CategoryOptions in
+      return result.union(AudioCategoryOptions(rawValue: option)?.toAVAudioSessionCategoryOptions() ?? [])
+    }) ?? []
     
+    do {
+      try audioSession.setCategory(category, options: options)
+      result(1)
+    } catch {
+      print(error)
+      result(0)
     }
+  }
 
   private func stop() {
     self.synthesizer.stopSpeaking(at: AVSpeechBoundary.immediate)

--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -8,7 +8,7 @@ typedef void ErrorHandler(dynamic message);
 typedef ProgressHandler = void Function(
     String text, int start, int end, String word);
 
-const String iosAudioCategoryOptionsKey = 'iosAudioCategoryOptions';
+const String iosAudioCategoryOptionsKey = 'iosAudioCategoryOptionsKey';
 const String iosAudioCategoryKey = 'iosAudioCategoryKey';
 const String iosAudioCategoryAmbientSolo = 'iosAudioCategoryAmbientSolo';
 const String iosAudioCategoryAmbient = 'iosAudioCategoryAmbient';
@@ -173,7 +173,7 @@ class FlutterTts {
       return _channel
           .invokeMethod<dynamic>('setIosAudioCategory', <String, dynamic>{
         iosAudioCategoryKey: categoryToString[category],
-        iosAudioCategoryOptionsKey: options.map((o) => optionsToString[o])
+        iosAudioCategoryOptionsKey: options.map((o) => optionsToString[o]).toList(),
       });
     } on PlatformException catch (e) {
       print(

--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -168,7 +168,7 @@ class FlutterTts {
       IosTextToSpeechAudioCategoryOptions.defaultToSpeaker:
           'iosAudioCategoryOptionsDefaultToSpeaker',
     };
-    if (!Platform.isAndroid) return;
+    if (!Platform.isIOS) return;
     try {
       return _channel
           .invokeMethod<dynamic>('setIosAudioCategory', <String, dynamic>{


### PR DESCRIPTION
Make sure method `setIosAudioCategory` is called on the channel only
when running on iOS platform and early return when the platform does not match iOS.

Fix passing audio category options to iOS
Change `iosAudioCategoryOptionsKey` to match on both Swift and Dart code. 
Change `iosAudioCategoryOptions` parameter to be a `List<String>`

