### PR TITLE
Using Voice class instead of Map + Including gender when available

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Sep 27 12:18:40 PDT 2019
+#Mon Aug 23 14:56:56 CST 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/android/src/main/java/com/tundralabs/fluttertts/FlutterTtsPlugin.java
+++ b/android/src/main/java/com/tundralabs/fluttertts/FlutterTtsPlugin.java
@@ -475,6 +475,10 @@ public class FlutterTtsPlugin implements MethodCallHandler, FlutterPlugin {
         HashMap<String, String> voiceMap = new HashMap<>();
         voiceMap.put("name", voice.getName());
         voiceMap.put("locale", voice.getLocale().toLanguageTag());
+
+        String gender = voice.getName().contains("female") ? "female"
+                : voice.getName().contains("male") ? "male" : "unspecified";
+        voiceMap.put("gender", gender);
         voices.add(voiceMap);
       }
       result.success(voices);

--- a/example/android/.settings/org.eclipse.buildship.core.prefs
+++ b/example/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,2 +1,13 @@
-#Sat Apr 14 11:55:40 PDT 2018
+arguments=
+auto.sync=false
+build.scans.enabled=false
+connection.gradle.distribution=GRADLE_DISTRIBUTION(VERSION(7.0-rc-1))
 connection.project.dir=
+eclipse.preferences.version=1
+gradle.user.home=
+java.home=/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home
+jvm.arguments=
+offline.mode=false
+override.workspace.settings=true
+show.console.view=true
+show.executions.view=true

--- a/example/android/app/.classpath
+++ b/example/android/app/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="bin/default"/>
 </classpath>

--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -318,6 +318,9 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
       for voice in AVSpeechSynthesisVoice.speechVoices() {
         voiceDict["name"] = voice.name
         voiceDict["locale"] = voice.language
+        let gender = voice.gender == AVSpeechSynthesisVoiceGender.female ? "female" 
+        : voice.gender == AVSpeechSynthesisVoiceGender.male ? "male" : "unspecified"
+        voiceDict["gender"] = gender
         voices.add(voiceDict)
       }
       result(voices)

--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -318,9 +318,15 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
       for voice in AVSpeechSynthesisVoice.speechVoices() {
         voiceDict["name"] = voice.name
         voiceDict["locale"] = voice.language
-        let gender = voice.gender == AVSpeechSynthesisVoiceGender.female ? "female" 
-        : voice.gender == AVSpeechSynthesisVoiceGender.male ? "male" : "unspecified"
-        voiceDict["gender"] = gender
+
+        if #available(iOS 13.0, *) { 
+          let gender = voice.gender == AVSpeechSynthesisVoiceGender.female ? "female" 
+                      : voice.gender == AVSpeechSynthesisVoiceGender.male ? "male" : "unspecified"
+          voiceDict["gender"] = gender
+        } else {
+          voiceDict["gender"] = "unspecified"
+        }
+        
         voices.add(voiceDict)
       }
       result(voices)

--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -3,6 +3,7 @@ import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_tts/models/tts_voice.dart';
 
 typedef void ErrorHandler(dynamic message);
 typedef ProgressHandler = void Function(
@@ -241,10 +242,16 @@ class FlutterTts {
   }
 
   /// [Future] which invokes the platform specific method for getVoices
-  /// Returns a `List` of `Maps` containing a voice name and locale
+  /// Returns a `List` of [TTSVoice] containing a voice object
   /// ***Android, iOS, and macOS supported only***
-  Future<dynamic> get getVoices async {
-    final voices = await _channel.invokeMethod('getVoices');
+  Future<List<TTSVoice>> get getVoices async {
+    final voicesObjs = await _channel.invokeMethod('getVoices') as List;
+    // Parse voices to class.
+    final voices = voicesObjs.map<TTSVoice>((Object? voiceObj) {
+      final voiceMap = voiceObj as Map?;
+
+      return TTSVoice.fromMap(voiceMap!);
+    }).toList();
     return voices;
   }
 

--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -3,7 +3,9 @@ import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_tts/models/tts_voice.dart';
+import 'package:flutter_tts/models/models.dart';
+
+export 'package:flutter_tts/models/models.dart';
 
 typedef void ErrorHandler(dynamic message);
 typedef ProgressHandler = void Function(

--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -213,8 +213,8 @@ class FlutterTts {
 
   /// [Future] which invokes the platform specific method for setVoice
   /// ***Android, iOS, and macOS supported only***
-  Future<dynamic> setVoice(Map<String, String> voice) async =>
-      _channel.invokeMethod('setVoice', voice);
+  Future<void> setVoice(TTSVoice voice) async =>
+      _channel.invokeMethod('setVoice', voice.asVoiceMap);
 
   /// [Future] which invokes the platform specific method for stop
   Future<dynamic> stop() async => _channel.invokeMethod('stop');

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -1,0 +1,1 @@
+export 'tts_voice.dart';

--- a/lib/models/tts_voice.dart
+++ b/lib/models/tts_voice.dart
@@ -1,0 +1,53 @@
+/// {@template tts_voice}
+/// Represents a wapper around Android's Voice class and
+/// Swift's AVSpeechSynthesisVoice class.
+///
+/// It exposes basic information about the underlying classes like the name,
+/// locale and gender of the synthetic voice.
+///
+/// {@endtemplate}
+class TTSVoice {
+  /// {@macro tts_voice}
+  const TTSVoice({
+    required this.name,
+    required this.locale,
+    required this.gender,
+  });
+
+  TTSVoice.fromMap(Map map)
+      : this.name = map['name']!.toString(),
+        this.locale = map['locale']!.toString(),
+        this.gender = TTSVoiceGenderFromString.fromString(
+          map['gender']!.toString(),
+        );
+
+  /// The tts_voice's name.
+  final String name;
+
+  /// The tts_voice's locale.
+  final String locale;
+
+  /// The tts_voice's gender.
+  final TTSVoiceGender gender;
+}
+
+enum TTSVoiceGender {
+  male,
+  female,
+  unspecified,
+}
+
+extension TTSVoiceGenderFromString on TTSVoiceGender {
+  static TTSVoiceGender fromString(String value) {
+    switch (value) {
+      case "female":
+        return TTSVoiceGender.female;
+
+      case "male":
+        return TTSVoiceGender.male;
+
+      default:
+        return TTSVoiceGender.unspecified;
+    }
+  }
+}

--- a/lib/models/tts_voice.dart
+++ b/lib/models/tts_voice.dart
@@ -29,6 +29,11 @@ class TTSVoice {
 
   /// The tts_voice's gender.
   final TTSVoiceGender gender;
+
+  Map<String, String> get asVoiceMap => {
+        'name': name,
+        'locale': locale,
+      };
 }
 
 enum TTSVoiceGender {

--- a/lib/models/tts_voice.dart
+++ b/lib/models/tts_voice.dart
@@ -50,4 +50,13 @@ extension TTSVoiceGenderFromString on TTSVoiceGender {
         return TTSVoiceGender.unspecified;
     }
   }
+
+  /// Helper to determine if value is male.
+  bool get isMale => this == TTSVoiceGender.male;
+
+  /// Helper to determine if value is female.
+  bool get isFemale => this == TTSVoiceGender.female;
+
+  /// Helper to determine if value is unspecified.
+  bool get isUnspecified => this == TTSVoiceGender.unspecified;
 }

--- a/macos/Classes/FlutterTtsPlugin.swift
+++ b/macos/Classes/FlutterTtsPlugin.swift
@@ -263,9 +263,13 @@ public class FlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizerDeleg
       for voice in AVSpeechSynthesisVoice.speechVoices() {
         voiceDict["name"] = voice.name
         voiceDict["locale"] = voice.language
-        let gender = voice.gender == AVSpeechSynthesisVoiceGender.female ? "female" 
-        : voice.gender == AVSpeechSynthesisVoiceGender.male ? "male" : "unspecified"
-        voiceDict["gender"] = gender
+        if #available(iOS 13.0, *) { 
+          let gender = voice.gender == AVSpeechSynthesisVoiceGender.female ? "female" 
+                      : voice.gender == AVSpeechSynthesisVoiceGender.male ? "male" : "unspecified"
+          voiceDict["gender"] = gender
+        } else {
+          voiceDict["gender"] = "unspecified"
+        }
         voices.add(voiceDict)
       }
       result(voices)

--- a/macos/Classes/FlutterTtsPlugin.swift
+++ b/macos/Classes/FlutterTtsPlugin.swift
@@ -263,6 +263,9 @@ public class FlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizerDeleg
       for voice in AVSpeechSynthesisVoice.speechVoices() {
         voiceDict["name"] = voice.name
         voiceDict["locale"] = voice.language
+        let gender = voice.gender == AVSpeechSynthesisVoiceGender.female ? "female" 
+        : voice.gender == AVSpeechSynthesisVoiceGender.male ? "male" : "unspecified"
+        voiceDict["gender"] = gender
         voices.add(voiceDict)
       }
       result(voices)


### PR DESCRIPTION
### Problem

I needed access to the underlying gender APIs provided by iOS, however it had to be done on a library level.

### Changelog

- Converts Maps of voices into a proper Dart class called `TTSVoice`.
- Provides a somewhat reliable API for checking gender in voices from Android or iOS platforms.
- 