### PR TITLE
[feature][iOS] Support for AVAudioSession.Mode

### DIFF
--- a/ios/Classes/AudioModes.swift
+++ b/ios/Classes/AudioModes.swift
@@ -10,54 +10,54 @@ enum AudioModes: String {
   case iosAudioModeVideoRecording
   case iosAudioModeVoiceChat
   case iosAudioModeVoicePrompt
-  
+
   func toAVAudioSessionMode() -> AVAudioSession.Mode? {
     switch self {
     case .iosAudioModeDefault:
-      if #available(iOS 12.0, *) {        
+      if #available(iOS 12.0, *) {
           return .default
       }
       return nil
     case .iosAudioModeGameChat:
-        if #available(iOS 12.0, *) {                
+        if #available(iOS 12.0, *) {
             return .gameChat
         }
         return nil
     case .iosAudioModeMeasurement:
-        if #available(iOS 12.0, *) {                
+        if #available(iOS 12.0, *) {
             return .measurement
         }
         return nil
     case .iosAudioModeMoviePlayback:
-        if #available(iOS 12.0, *) {        
+        if #available(iOS 12.0, *) {
             return .moviePlayback
         }
         return nil
     case .iosAudioModeSpokenAudio:
-        if #available(iOS 12.0, *) {        
+        if #available(iOS 12.0, *) {
             return .spokenAudio
         }
         return nil
     case .iosAudioModeVideoChat:
-        if #available(iOS 12.0, *) {        
+        if #available(iOS 12.0, *) {
             return .videoChat
         }
         return nil
     case .iosAudioModeVideoRecording:
-        if #available(iOS 12.0, *) {        
+        if #available(iOS 12.0, *) {
             return .videoRecording
         }
         return nil
     case .iosAudioModeVoiceChat:
-        if #available(iOS 12.0, *) {            
+        if #available(iOS 12.0, *) {
             return .voiceChat
         }
         return nil
     case .iosAudioModeVoicePrompt:
-        if #available(iOS 12.0, *) {                
+        if #available(iOS 12.0, *) {
             return .voicePrompt
         }
-        return nil  
+        return nil
     }
   }
 }

--- a/ios/Classes/AudioModes.swift
+++ b/ios/Classes/AudioModes.swift
@@ -1,0 +1,63 @@
+import AVFoundation
+
+enum AudioModes: String {
+  case iosAudioModeDefault
+  case iosAudioModeGameChat
+  case iosAudioModeMeasurement
+  case iosAudioModeMoviePlayback
+  case iosAudioModeSpokenAudio
+  case iosAudioModeVideoChat
+  case iosAudioModeVideoRecording
+  case iosAudioModeVoiceChat
+  case iosAudioModeVoicePrompt
+  
+  func toAVAudioSessionMode() -> AVAudioSession.Mode? {
+    switch self {
+    case .iosAudioModeDefault:
+      if #available(iOS 12.0, *) {        
+          return .default
+      }
+      return nil
+    case .iosAudioModeGameChat:
+        if #available(iOS 12.0, *) {                
+            return .gameChat
+        }
+        return nil
+    case .iosAudioModeMeasurement:
+        if #available(iOS 12.0, *) {                
+            return .measurement
+        }
+        return nil
+    case .iosAudioModeMoviePlayback:
+        if #available(iOS 12.0, *) {        
+            return .moviePlayback
+        }
+        return nil
+    case .iosAudioModeSpokenAudio:
+        if #available(iOS 12.0, *) {        
+            return .spokenAudio
+        }
+        return nil
+    case .iosAudioModeVideoChat:
+        if #available(iOS 12.0, *) {        
+            return .videoChat
+        }
+        return nil
+    case .iosAudioModeVideoRecording:
+        if #available(iOS 12.0, *) {        
+            return .videoRecording
+        }
+        return nil
+    case .iosAudioModeVoiceChat:
+        if #available(iOS 12.0, *) {            
+            return .voiceChat
+        }
+        return nil
+    case .iosAudioModeVoicePrompt:
+        if #available(iOS 12.0, *) {                
+            return .voicePrompt
+        }
+        return nil  
+    }
+  }
+}

--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -124,15 +124,6 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
       }
       let audioCategory = args["iosAudioCategoryKey"] as? String
       let audioOptions = args[iosAudioCategoryOptionsKey] as? Array<String>
-      self.setAudioCategory(audioCategory: audioCategory, audioOptions: audioOptions, audioMode: nil, result: result)
-      break
-    case "setIosAudioCategoryAndMode":
-      guard let args = call.arguments as? [String: Any] else {
-        result("iOS could not recognize flutter arguments in method: (sendParams)")
-        return
-      }
-      let audioCategory = args["iosAudioCategoryKey"] as? String
-      let audioOptions = args[iosAudioCategoryOptionsKey] as? Array<String>
       let audioModes = args[iosAudioModeKey] as? String
       self.setAudioCategory(audioCategory: audioCategory, audioOptions: audioOptions, audioMode: audioModes, result: result)
       break

--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -277,7 +277,11 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
     }) ?? []
     
     do {
-        try audioSession.setCategory(category, mode: AVAudioSession.VoicePrompt, options: options)
+        if #available(iOS 12.0, *) {        
+            try audioSession.setCategory(category, mode: AVAudioSessionMode.VoicePrompt, options: options)
+        } else {
+            try audioSession.setCategory(category, options: options)            
+        }
       result(1)
     } catch {
       print(error)

--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -278,7 +278,7 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
     
     do {
         if #available(iOS 12.0, *) {        
-            try audioSession.setCategory(category, mode: AVAudioSessionMode.VoicePrompt, options: options)
+            try audioSession.setCategory(category, mode: .voicePrompt, options: options)
         } else {
             try audioSession.setCategory(category, options: options)            
         }

--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -277,7 +277,7 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
     }) ?? []
     
     do {
-      try audioSession.setCategory(category, options: options)
+        try audioSession.setCategory(category, mode: AVAudioSession.VoicePrompt, options: options)
       result(1)
     } catch {
       print(error)
@@ -353,13 +353,13 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
   }
   
   public func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
-    // if shouldDeactivateAndNotifyOthers(audioSession) {
-    //   do {
-    //     try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
-    //   } catch {
-    //     print(error)
-    //   }
-    // }
+    if shouldDeactivateAndNotifyOthers(audioSession) {
+      do {
+        try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+      } catch {
+        print(error)
+      }
+    }
     if self.awaitSpeakCompletion {
       self.speakResult(1)
     }

--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -26,12 +26,13 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
     self.channel = channel
     synthesizer.delegate = self
     setLanguages()
+    
     // Allow audio playback when the Ring/Silent switch is set to silent
-    do {
-        try audioSession.setCategory(.playAndRecord, options: [.defaultToSpeaker])
-    } catch {
-      print(error)
-    }
+    // do {
+    //     try audioSession.setCategory(.playAndRecord, options: [.defaultToSpeaker])
+    // } catch {
+    //   print(error)
+    // }
   }
 
   private func setLanguages() {

--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -26,13 +26,6 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
     self.channel = channel
     synthesizer.delegate = self
     setLanguages()
-    
-    // Allow audio playback when the Ring/Silent switch is set to silent
-    // do {
-    //     try audioSession.setCategory(.playAndRecord, options: [.defaultToSpeaker])
-    // } catch {
-    //   print(error)
-    // }
   }
 
   private func setLanguages() {

--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -353,13 +353,13 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
   }
   
   public func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
-    if shouldDeactivateAndNotifyOthers(audioSession) {
-      do {
-        try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
-      } catch {
-        print(error)
-      }
-    }
+    // if shouldDeactivateAndNotifyOthers(audioSession) {
+    //   do {
+    //     try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+    //   } catch {
+    //     print(error)
+    //   }
+    // }
     if self.awaitSpeakCompletion {
       self.speakResult(1)
     }

--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -27,11 +27,11 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
     setLanguages()
     
     // Allow audio playback when the Ring/Silent switch is set to silent
-    do {
-        try audioSession.setCategory(.playAndRecord, options: [.defaultToSpeaker])
-    } catch {
-      print(error)
-    }
+    // do {
+    //     try audioSession.setCategory(.playAndRecord, options: [.defaultToSpeaker])
+    // } catch {
+    //   print(error)
+    // }
   }
 
   private func setLanguages() {

--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -194,46 +194,7 @@ class FlutterTts {
   /// [Future] which invokes the platform specific method for setting audio category
   /// ***Ios supported only***
   Future<dynamic> setIosAudioCategory(IosTextToSpeechAudioCategory category,
-      List<IosTextToSpeechAudioCategoryOptions> options) async {
-    const categoryToString = <IosTextToSpeechAudioCategory, String>{
-      IosTextToSpeechAudioCategory.ambientSolo: iosAudioCategoryAmbientSolo,
-      IosTextToSpeechAudioCategory.ambient: iosAudioCategoryAmbient,
-      IosTextToSpeechAudioCategory.playback: iosAudioCategoryPlayback
-    };
-    const optionsToString = {
-      IosTextToSpeechAudioCategoryOptions.mixWithOthers:
-          'iosAudioCategoryOptionsMixWithOthers',
-      IosTextToSpeechAudioCategoryOptions.duckOthers:
-          'iosAudioCategoryOptionsDuckOthers',
-      IosTextToSpeechAudioCategoryOptions.interruptSpokenAudioAndMixWithOthers:
-          'iosAudioCategoryOptionsInterruptSpokenAudioAndMixWithOthers',
-      IosTextToSpeechAudioCategoryOptions.allowBluetooth:
-          'iosAudioCategoryOptionsAllowBluetooth',
-      IosTextToSpeechAudioCategoryOptions.allowBluetoothA2DP:
-          'iosAudioCategoryOptionsAllowBluetoothA2DP',
-      IosTextToSpeechAudioCategoryOptions.allowAirPlay:
-          'iosAudioCategoryOptionsAllowAirPlay',
-      IosTextToSpeechAudioCategoryOptions.defaultToSpeaker:
-          'iosAudioCategoryOptionsDefaultToSpeaker',
-    };
-    if (!Platform.isIOS) return;
-    try {
-      return _channel
-          .invokeMethod<dynamic>('setIosAudioCategory', <String, dynamic>{
-        iosAudioCategoryKey: categoryToString[category],
-        iosAudioCategoryOptionsKey:
-            options.map((o) => optionsToString[o]).toList(),
-      });
-    } on PlatformException catch (e) {
-      print(
-          'setIosAudioCategory error, category: $category, error: ${e.message}');
-    }
-  }
-
-  /// [Future] which invokes the platform specific method for setting audio category
-  /// ***Ios supported only***
-  Future<dynamic> setIosAudioCategoryAndMode(IosTextToSpeechAudioCategory category,
-      List<IosTextToSpeechAudioCategoryOptions> options, IosTextToSpeechAudioMode mode) async {
+    List<IosTextToSpeechAudioCategoryOptions> options, [IosTextToSpeechAudioMode mode = IosTextToSpeechAudioMode.defaultMode]) async {
     const categoryToString = <IosTextToSpeechAudioCategory, String>{
       IosTextToSpeechAudioCategory.ambientSolo: iosAudioCategoryAmbientSolo,
       IosTextToSpeechAudioCategory.ambient: iosAudioCategoryAmbient,
@@ -269,7 +230,7 @@ class FlutterTts {
     if (!Platform.isIOS) return;
     try {
       return _channel
-          .invokeMethod<dynamic>('setIosAudioCategoryAndMode', <String, dynamic>{
+          .invokeMethod<dynamic>('setIosAudioCategory', <String, dynamic>{
         iosAudioCategoryKey: categoryToString[category],
         iosAudioCategoryOptionsKey:
             options.map((o) => optionsToString[o]).toList(),

--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -10,6 +10,7 @@ typedef ProgressHandler = void Function(
 
 const String iosAudioCategoryOptionsKey = 'iosAudioCategoryOptionsKey';
 const String iosAudioCategoryKey = 'iosAudioCategoryKey';
+const String iosAudioModeKey = 'iosAudioModeKey';
 const String iosAudioCategoryAmbientSolo = 'iosAudioCategoryAmbientSolo';
 const String iosAudioCategoryAmbient = 'iosAudioCategoryAmbient';
 const String iosAudioCategoryPlayback = 'iosAudioCategoryPlayback';
@@ -31,6 +32,25 @@ const String iosAudioCategoryOptionsAllowAirPlay =
 const String iosAudioCategoryOptionsDefaultToSpeaker =
     'iosAudioCategoryOptionsDefaultToSpeaker';
 
+const String iosAudioModeDefault =
+    'iosAudioModeDefault';
+const String iosAudioModeGameChat =
+    'iosAudioModeGameChat';
+const String iosAudioModeMeasurement =
+    'iosAudioModeMeasurement';
+const String iosAudioModeMoviePlayback =
+    'iosAudioModeMoviePlayback';
+const String iosAudioModeSpokenAudio =
+    'iosAudioModeSpokenAudio';
+const String iosAudioModeVideoChat =
+    'iosAudioModeVideoChat';
+const String iosAudioModeVideoRecording =
+    'iosAudioModeVideoRecording';
+const String iosAudioModeVoiceChat =
+    'iosAudioModeVoiceChat';
+const String iosAudioModeVoicePrompt =
+    'iosAudioModeVoicePrompt';
+
 enum TextToSpeechPlatform { android, ios }
 
 enum IosTextToSpeechAudioCategory {
@@ -51,6 +71,18 @@ enum IosTextToSpeechAudioCategory {
   ///  such as for a Voice over Internet Protocol (VoIP) app.
   /// The default value.
   playAndRecord,
+}
+
+enum IosTextToSpeechAudioMode {
+  defaultMode,
+  gameChat,
+  measurement,
+  moviePlayback,
+  spokenAudio,
+  videoChat,
+  videoRecording,
+  voiceChat,
+  voicePrompt,
 }
 
 enum IosTextToSpeechAudioCategoryOptions {
@@ -195,6 +227,57 @@ class FlutterTts {
     } on PlatformException catch (e) {
       print(
           'setIosAudioCategory error, category: $category, error: ${e.message}');
+    }
+  }
+
+  /// [Future] which invokes the platform specific method for setting audio category
+  /// ***Ios supported only***
+  Future<dynamic> setIosAudioCategoryAndMode(IosTextToSpeechAudioCategory category,
+      List<IosTextToSpeechAudioCategoryOptions> options, IosTextToSpeechAudioMode mode) async {
+    const categoryToString = <IosTextToSpeechAudioCategory, String>{
+      IosTextToSpeechAudioCategory.ambientSolo: iosAudioCategoryAmbientSolo,
+      IosTextToSpeechAudioCategory.ambient: iosAudioCategoryAmbient,
+      IosTextToSpeechAudioCategory.playback: iosAudioCategoryPlayback
+    };
+    const optionsToString = {
+      IosTextToSpeechAudioCategoryOptions.mixWithOthers:
+          'iosAudioCategoryOptionsMixWithOthers',
+      IosTextToSpeechAudioCategoryOptions.duckOthers:
+          'iosAudioCategoryOptionsDuckOthers',
+      IosTextToSpeechAudioCategoryOptions.interruptSpokenAudioAndMixWithOthers:
+          'iosAudioCategoryOptionsInterruptSpokenAudioAndMixWithOthers',
+      IosTextToSpeechAudioCategoryOptions.allowBluetooth:
+          'iosAudioCategoryOptionsAllowBluetooth',
+      IosTextToSpeechAudioCategoryOptions.allowBluetoothA2DP:
+          'iosAudioCategoryOptionsAllowBluetoothA2DP',
+      IosTextToSpeechAudioCategoryOptions.allowAirPlay:
+          'iosAudioCategoryOptionsAllowAirPlay',
+      IosTextToSpeechAudioCategoryOptions.defaultToSpeaker:
+          'iosAudioCategoryOptionsDefaultToSpeaker',
+        };
+        const modeToString = <IosTextToSpeechAudioMode, String> {
+          IosTextToSpeechAudioMode.defaultMode: iosAudioModeDefault,
+          IosTextToSpeechAudioMode.gameChat: iosAudioModeGameChat,
+          IosTextToSpeechAudioMode.measurement: iosAudioModeMeasurement,
+          IosTextToSpeechAudioMode.moviePlayback: iosAudioModeMoviePlayback,
+          IosTextToSpeechAudioMode.spokenAudio: iosAudioModeSpokenAudio,
+          IosTextToSpeechAudioMode.videoChat: iosAudioModeVideoChat,
+          IosTextToSpeechAudioMode.videoRecording: iosAudioModeVideoRecording,
+          IosTextToSpeechAudioMode.voiceChat: iosAudioModeVoiceChat,
+          IosTextToSpeechAudioMode.voicePrompt: iosAudioModeVoicePrompt,
+        };
+    if (!Platform.isIOS) return;
+    try {
+      return _channel
+          .invokeMethod<dynamic>('setIosAudioCategoryAndMode', <String, dynamic>{
+        iosAudioCategoryKey: categoryToString[category],
+        iosAudioCategoryOptionsKey:
+            options.map((o) => optionsToString[o]).toList(),
+        iosAudioModeKey: modeToString[mode],
+      });
+    } on PlatformException catch (e) {
+      print(
+          'setIosAudioCategoryAndMode error, category: $category, mode: $mode, error: ${e.message}');
     }
   }
 

--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -238,7 +238,7 @@ class FlutterTts {
       });
     } on PlatformException catch (e) {
       print(
-          'setIosAudioCategoryAndMode error, category: $category, mode: $mode, error: ${e.message}');
+          'setIosAudioCategory error, category: $category, mode: $mode, error: ${e.message}');
     }
   }
 


### PR DESCRIPTION
## Problem

The simultaneous use of _flutter_tts_ along with video player or other audio session results in non-mixable audio session in which the background audio stops. For example, using _flutter_tts_ and muted video along with playing music with Spotify results in music getting stop. 

In order to fix this issue, the new [AVAudioSession.Mode](https://developer.apple.com/documentation/avfaudio/avaudiosession/mode) could be used. As well as, using Ambient from AVAudioSession.Category.

This PR, solves the issue of background music getting stopped, when additional audio session are active and add support for the new _AVAudioSession.Mode_.

It should solve issue #287 as well.

## Changelog
- Add support for _AVAudioSession.Mode_ as last argument of _.setIosAudioCategory(...)_ method.
- Remove setup code for _AVAudioSession_ in _init(...)_ method ( e.g. this could interfere with video_player and other audio sessions, in vivo using _.setSharedInstance(...)_ provides much finer control over the behaviour of the audio session )
- Supports following audio modes:
```
     IosTextToSpeechAudioMode.defaultMode
     IosTextToSpeechAudioMode.gameChat
     IosTextToSpeechAudioMode.measurement
     IosTextToSpeechAudioMode.moviePlayback
     IosTextToSpeechAudioMode.spokenAudio
     IosTextToSpeechAudioMode.videoChat
     IosTextToSpeechAudioMode.videoRecording
     IosTextToSpeechAudioMode.voiceChat
     IosTextToSpeechAudioMode.voicePrompt
```

## Example

The following setup allows background music and in-app audio session to continue simultaneously:

```dart
FlutterTts flutterTts = FlutterTts();
await flutterTts.setIosAudioCategory(IosTextToSpeechAudioCategory.ambient,
     [
          IosTextToSpeechAudioCategoryOptions.allowBluetooth,
          IosTextToSpeechAudioCategoryOptions.allowBluetoothA2DP,
          IosTextToSpeechAudioCategoryOptions.mixWithOthers
     ],
     IosTextToSpeechAudioMode.voicePrompt
);
``` 