### PR TITLE
Two small bug fixes.

### DIFF
--- a/lib/flutter_tts_web.dart
+++ b/lib/flutter_tts_web.dart
@@ -14,7 +14,7 @@ class FlutterTtsPlugin {
 
   TtsState ttsState = TtsState.stopped;
 
-  late Completer? _speechCompleter;
+  Completer? _speechCompleter;
 
   get isPlaying => ttsState == TtsState.playing;
 

--- a/lib/flutter_tts_web.dart
+++ b/lib/flutter_tts_web.dart
@@ -92,7 +92,7 @@ class FlutterTtsPlugin {
         _speechCompleter = null;
       }
       t?.cancel();
-      channel.invokeMethod("speak.onError", e);
+      channel.invokeMethod("speak.onError", e.toString());
     };
   }
 


### PR DESCRIPTION
1.  A variable marked `late` has a chance of (correctly) never being initialized. Remove `late`.

2. In the web plugin, there's an attempt to send a `SpeechSynthesisEvent` through a message channel using the standard codec, which only accepts primitive types. 