### PR TITLE
Audio Session Auto Stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## 3.7.0
+
+- **iOS:** add option to disable the auto stop for the audio session after speech completion
+
 ## 3.6.3
 
 - **Android:** fixed initHandler with setEngineInitHandler

--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -114,7 +114,9 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
       self.setSharedInstance(sharedInstance: sharedInstance, result: result)
       break
     case "autoStopSharedSession":
-      self.autoStopSharedSession = call.arguments as! Bool
+      let autoStop = call.arguments as! Bool
+      self.autoStopSharedSession = autoStop
+      result(1)
       break
     case "setIosAudioCategory":
       guard let args = call.arguments as? [String: Any] else {

--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -16,6 +16,7 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
   var voice: AVSpeechSynthesisVoice?
   var awaitSpeakCompletion: Bool = false
   var awaitSynthCompletion: Bool = false
+  var autoStopSharedSession: Bool = true
   var speakResult: FlutterResult? = nil
   var synthResult: FlutterResult? = nil
     
@@ -111,6 +112,9 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
     case "setSharedInstance":
       let sharedInstance = call.arguments as! Bool
       self.setSharedInstance(sharedInstance: sharedInstance, result: result)
+      break
+    case "autoStopSharedSession":
+      self.autoStopSharedSession = call.arguments as! Bool
       break
     case "setIosAudioCategory":
       guard let args = call.arguments as? [String: Any] else {
@@ -356,7 +360,7 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
   }
 
   public func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
-    if shouldDeactivateAndNotifyOthers(audioSession) {
+    if shouldDeactivateAndNotifyOthers(audioSession) && self.autoStopSharedSession {
       do {
         try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
       } catch {

--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -183,6 +183,12 @@ class FlutterTts {
   Future<dynamic> setSharedInstance(bool sharedSession) async =>
       await _channel.invokeMethod('setSharedInstance', sharedSession);
 
+  /// [Future] which invokes the platform specific method for setting the autoStopSharedSession
+  /// default value is true
+  /// *** iOS, and macOS supported only***
+  Future<dynamic> autoStopSharedSession(bool autoStop) async =>
+      await _channel.invokeMethod('autoStopSharedSession', autoStop);
+
   /// [Future] which invokes the platform specific method for setting audio category
   /// ***Ios supported only***
   Future<dynamic> setIosAudioCategory(IosTextToSpeechAudioCategory category,

--- a/macos/Classes/FlutterTtsPlugin.swift
+++ b/macos/Classes/FlutterTtsPlugin.swift
@@ -105,6 +105,10 @@ public class FlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizerDeleg
       }
       self.setVoice(voice: args, result: result)
       break
+    case "autoStopSharedSession":
+      // MacOS does not have a shared audio session so just accept the call
+      result(1)
+      break
     default:
       result(FlutterMethodNotImplemented)
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,5 +29,5 @@ flutter:
         fileName: flutter_tts_web.dart
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0-0 <4.0.0'
   flutter: '>=1.22.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_tts
 description: A flutter plugin for Text to Speech.  This plugin is supported on iOS, Android, Web, & macOS.
-version: 3.6.3
+version: 3.7.0
 homepage: https://github.com/dlutton/flutter_tts
 
 dependencies:


### PR DESCRIPTION
Adds a new method call to disable the functionality that auto deactivates the shared audio session after speech completion to allow callers more control over the session using dedicated session management libraries.