### PR TITLE
Support project import fallback if the generated compatibility header…

### DIFF
--- a/ios/Classes/FlutterTtsPlugin.m
+++ b/ios/Classes/FlutterTtsPlugin.m
@@ -1,5 +1,12 @@
 #import "FlutterTtsPlugin.h"
+#if __has_include(<flutter_tts/flutter_tts-Swift.h>)
 #import <flutter_tts/flutter_tts-Swift.h>
+#else
+// Support project import fallback if the generated compatibility header
+// is not copied when this plugin is created as a library.
+// https://forums.swift.org/t/swift-static-libraries-dont-copy-generated-objective-c-header/19816
+#import "flutter_tts-Swift.h"
+#endif
 
 @implementation FlutterTtsPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {


### PR DESCRIPTION
The fix is to support project import fallback if the generated compatibility header is not copied when this plugin is created as a library. Without this fix some plugin users may encounter the following error: _"'flutter_tts/flutter_tts-Swift.h' file not found"_.

Many plugins do the same, including:

* **flutter-facebook-auth** (https://github.com/darwin-morocho/flutter-facebook-auth/blob/master/facebook_auth/ios/Classes/FlutterFacebookAuthPlugin.m)
* **pasteboard plugin** (https://github.com/MixinNetwork/flutter-plugins/blob/main/packages/pasteboard/ios/Classes/PasteboardPlugin.m)
* **sign_in_with_apple** (https://github.com/aboutyou/dart_packages/blob/master/packages/sign_in_with_apple/sign_in_with_apple/ios/Classes/SignInWithApplePlugin.m)
* etc.

Please merge this fix.