### PR TITLE
Add `try-catch` on initializing web plugin.

### DIFF
--- a/lib/flutter_tts_web.dart
+++ b/lib/flutter_tts_web.dart
@@ -36,14 +36,19 @@ class FlutterTtsPlugin {
   List<dynamic>? voices;
   List<String?>? languages;
   Timer? t;
+  bool supported = false;
 
   FlutterTtsPlugin() {
-    utterance = new js.JsObject(
-        js.context["SpeechSynthesisUtterance"] as js.JsFunction, [""]);
-    synth = new js.JsObject.fromBrowserObject(
-        js.context["speechSynthesis"] as js.JsObject);
-
-    _listeners();
+    try {
+      utterance = new js.JsObject(
+          js.context["SpeechSynthesisUtterance"] as js.JsFunction, [""]);
+      synth = new js.JsObject.fromBrowserObject(
+          js.context["speechSynthesis"] as js.JsObject);
+      _listeners();
+      supported = true;
+    } catch (e) {
+      print('Initialization of TTS failed. Functions are disabled. Error: $e');
+    }
   }
 
   void _listeners() {
@@ -97,6 +102,7 @@ class FlutterTtsPlugin {
   }
 
   Future<dynamic> handleMethodCall(MethodCall call) async {
+    if (!supported) return;
     switch (call.method) {
       case 'speak':
         final text = call.arguments as String?;


### PR DESCRIPTION
Since [Web Speech API (Synthesis)](https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API#api.speechsynthesis) is not supported on all browser, the whole plugin won't work on them.
Their may be some workaround but simply mute method calls should work for now.

This patch is only tested in @guiyunbao's internal project and proved works.
Please consider test with more project.

Close #391, and should resolve #283 too.