### PR TITLE
fix(android): ConcurrentModificationException.

### DIFF
--- a/android/src/main/kotlin/com/tundralabs/fluttertts/FlutterTtsPlugin.kt
+++ b/android/src/main/kotlin/com/tundralabs/fluttertts/FlutterTtsPlugin.kt
@@ -199,11 +199,13 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
                 }
 
                 // Handle pending method calls (sent while TTS was initializing)
-                isTtsInitialized = true
-                for (call in pendingMethodCalls) {
-                    call.run()
+                synchronized(this@FlutterTtsPlugin) {
+                    isTtsInitialized = true
+                    for (call in pendingMethodCalls) {
+                        call.run()
+                    }
+                    pendingMethodCalls.clear()
                 }
-                pendingMethodCalls.clear()
                 invokeMethod("tts.init", isTtsInitialized)
             } else {
                 Log.e(tag, "Failed to initialize TextToSpeech with status: $status")
@@ -227,9 +229,12 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
                 }
 
                 // Handle pending method calls (sent while TTS was initializing)
-                isTtsInitialized = true
-                for (call in pendingMethodCalls) {
-                    call.run()
+                synchronized(this@FlutterTtsPlugin) {
+                    isTtsInitialized = true
+                    for (call in pendingMethodCalls) {
+                        call.run()
+                    }
+                    pendingMethodCalls.clear()
                 }
             } else {
                 Log.e(tag, "Failed to initialize TextToSpeech with status: $status")
@@ -238,11 +243,13 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
 
     override fun onMethodCall(call: MethodCall, result: Result) {
         // If TTS is still loading
-        if (!isTtsInitialized) {
-            // Suspend method call until the TTS engine is ready
-            val suspendedCall = Runnable { onMethodCall(call, result) }
-            pendingMethodCalls.add(suspendedCall)
-            return
+        synchronized(this@FlutterTtsPlugin) {
+            if (!isTtsInitialized) {
+                // Suspend method call until the TTS engine is ready
+                val suspendedCall = Runnable { onMethodCall(call, result) }
+                pendingMethodCalls.add(suspendedCall)
+                return
+            }
         }
         when (call.method) {
             "speak" -> {
@@ -270,8 +277,10 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
                 }
                 val b = speak(text)
                 if (!b) {
-                    val suspendedCall = Runnable { onMethodCall(call, result) }
-                    pendingMethodCalls.add(suspendedCall)
+                    synchronized(this@FlutterTtsPlugin) {
+                        val suspendedCall = Runnable { onMethodCall(call, result) }
+                        pendingMethodCalls.add(suspendedCall)
+                    }
                     return
                 }
                 // Only use await speak completion if queueMode is set to QUEUE_FLUSH


### PR DESCRIPTION
```
Fatal Exception: java.util.ConcurrentModificationException:
       at java.util.ArrayList$Itr.next(ArrayList.java:860)
       at com.tundralabs.fluttertts.FlutterTtsPlugin.onInitListener$lambda$2(FlutterTtsPlugin.java:103)
       at android.speech.tts.TextToSpeech.lambda$dispatchOnInit$0$android-speech-tts-TextToSpeech(TextToSpeech.java:890)
       at android.speech.tts.TextToSpeech$$ExternalSyntheticLambda1.run(:4)
       at android.speech.tts.TextToSpeech.dispatchOnInit(TextToSpeech.java:899)
       at android.speech.tts.TextToSpeech.-$$Nest$mdispatchOnInit()
       at android.speech.tts.TextToSpeech$Connection$SetupConnectionAsyncTask.onPostExecute(TextToSpeech.java:2280)
       at android.speech.tts.TextToSpeech$Connection$SetupConnectionAsyncTask.onPostExecute(TextToSpeech.java:2240)
       at android.os.AsyncTask.finish(AsyncTask.java:771)
       at android.os.AsyncTask.-$$Nest$mfinish()
       at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:788)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:210)
       at android.os.Looper.loop(Looper.java:299)
       at android.app.ActivityThread.main(ActivityThread.java:8261)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:559)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:954)
```