### PR TITLE
Fabio Parra: Set speakResult to null when speakCompletion is done.

### DIFF
--- a/android/src/main/kotlin/com/tundralabs/fluttertts/FlutterTtsPlugin.kt
+++ b/android/src/main/kotlin/com/tundralabs/fluttertts/FlutterTtsPlugin.kt
@@ -175,7 +175,10 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
 
     fun speakCompletion(success: Int) {
         speaking = false
-        handler!!.post { speakResult?.success(success) }
+        handler!!.post {
+            speakResult?.success(success)
+            speakResult = null
+        }
     }
 
     fun synthCompletion(success: Int) {


### PR DESCRIPTION
I think that this pull request will fix #397 

speakResult is set to null on stop but on speakCompletion is missing this line.