### PR TITLE
return additional voice information fields on ios

### DIFF
--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -327,6 +327,9 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
       for voice in AVSpeechSynthesisVoice.speechVoices() {
         voiceDict["name"] = voice.name
         voiceDict["locale"] = voice.language
+        voiceDict["quality"] = voice.quality.stringValue
+        voiceDict["gender"] = voice.gender.stringValue
+        voiceDict["identifier"] = voice.identifier
         voices.add(voiceDict)
       }
       result(voices)
@@ -407,4 +410,30 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
     self.channel.invokeMethod("speak.onProgress", arguments: data)
   }
 
+}
+
+extension AVSpeechSynthesisVoiceQuality {
+    var stringValue: String {
+        switch self {
+        case .default:
+            return "default"
+        case .premium:
+            return "premium"
+        case .enhanced:
+            return "enhanced"
+        }
+    }
+}
+
+extension AVSpeechSynthesisVoiceGender {
+    var stringValue: String {
+        switch self {
+        case .male:
+            return "male"
+        case .female:
+            return "female"
+        case .unspecified:
+            return "unspecified"
+        }
+    }
 }


### PR DESCRIPTION
Apple (in its infinite wisdom) seems to have partially [removed Eloquence voices](https://applevis.com/forum/ios-ipados/eloquence-speach-synthesizer-seems-be-removed-ios) from iOS 17 - but only partially: the voices are still returned to getVoices(), but they can't be used to speak:

```
Could not retrieve voice [AVSpeechSynthesisProviderVoice 0x280a372a0] Name: Rocko, Identifier: com.apple.eloquence.en-GB.Rocko, Supported Languages (
    "en-GB"
), Age: 0, Gender: 0, Size: 0, Version: (null)
[AXTTSCommon] Audio Unit failed to start after 5 attempts.
[AXTTSCommon] VoiceProvider: Could not start synthesis for request SSML Length: 94, Voice: [AVSpeechSynthesisProviderVoice 0x280a372a0] Name: Rocko, Identifier: com.apple.eloquence.en-GB.Rocko, Supported Languages (
    "en-GB"
), Age: 0, Gender: 0, Size: 0, Version: (null), converted from tts request [TTSSpeechRequest 0x281665ef0] <speak><voice name="com.apple.eloquence.en-GB.Rocko">They achieved their goal.</voice></speak> language: en-GB footprint: premium rate: 0.500000 pitch: 1.000000 volume: 1.000000
```

For good measure it actually pronounces the tags (<speak><voice>, etc.) Seems like there's no [simple workaround](https://developer.apple.com/forums/thread/730789) for this, so until the voices are fixed, the Eloquence voices need to be skipped.

This diff adds the voice identifier field to allow not using Eloquence, plus a couple of other fields that would be useful to select a better voice.