### PR TITLE
fix(android): when TextToSpeech initialization fails, the dart side method will always be in a pending state .

### DIFF
--- a/android/src/main/kotlin/com/tundralabs/fluttertts/FlutterTtsPlugin.kt
+++ b/android/src/main/kotlin/com/tundralabs/fluttertts/FlutterTtsPlugin.kt
@@ -458,9 +458,9 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
     }
 
     private fun setEngine(engine: String?, result: Result) {
-        tts = TextToSpeech(context, onInitListener, engine)
         ttsStatus = null
         engineResult = result
+        tts = TextToSpeech(context, onInitListener, engine)
     }
 
     private fun setLanguage(language: String?, result: Result) {

--- a/android/src/main/kotlin/com/tundralabs/fluttertts/FlutterTtsPlugin.kt
+++ b/android/src/main/kotlin/com/tundralabs/fluttertts/FlutterTtsPlugin.kt
@@ -29,8 +29,6 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
     private var context: Context? = null
     private var tts: TextToSpeech? = null
     private val tag = "TTS"
-    private val googleTtsEngine = "com.google.android.tts"
-    private var isTtsInitialized = false
     private val pendingMethodCalls = ArrayList<Runnable>()
     private val utterances = HashMap<String, String>()
     private var bundle: Bundle? = null
@@ -40,6 +38,8 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
     private var pauseText: String? = null
     private var isPaused: Boolean = false
     private var queueMode: Int = TextToSpeech.QUEUE_FLUSH
+    private var ttsStatus: Int? = null
+    private var engineResult: Result? = null
 
     companion object {
         private const val SILENCE_PREFIX = "SIL_"
@@ -52,7 +52,7 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
         methodChannel!!.setMethodCallHandler(this)
         handler = Handler(Looper.getMainLooper())
         bundle = Bundle()
-        tts = TextToSpeech(context, firstTimeOnInitListener, googleTtsEngine)
+        tts = TextToSpeech(context, firstTimeOnInitListener)
     }
 
     /** Android Plugin APIs  */
@@ -188,6 +188,15 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
 
     private val onInitListener: TextToSpeech.OnInitListener =
         TextToSpeech.OnInitListener { status ->
+            // Handle pending method calls (sent while TTS was initializing)
+            synchronized(this@FlutterTtsPlugin) {
+                ttsStatus = status
+                for (call in pendingMethodCalls) {
+                    call.run()
+                }
+                pendingMethodCalls.clear()
+            }
+
             if (status == TextToSpeech.SUCCESS) {
                 tts!!.setOnUtteranceProgressListener(utteranceProgressListener)
                 try {
@@ -201,23 +210,24 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
                     Log.e(tag, "getDefaultLocale: " + e.message)
                 }
 
-                // Handle pending method calls (sent while TTS was initializing)
-                synchronized(this@FlutterTtsPlugin) {
-                    isTtsInitialized = true
-                    for (call in pendingMethodCalls) {
-                        call.run()
-                    }
-                    pendingMethodCalls.clear()
-                }
-                invokeMethod("tts.init", isTtsInitialized)
+                engineResult!!.success(1)
             } else {
-                Log.e(tag, "Failed to initialize TextToSpeech with status: $status")
-                invokeMethod("tts.init", isTtsInitialized)
+                engineResult!!.error("TtsError","Failed to initialize TextToSpeech with status: $status", null)
             }
+            engineResult = null
         }
 
     private val firstTimeOnInitListener: TextToSpeech.OnInitListener =
         TextToSpeech.OnInitListener { status ->
+            // Handle pending method calls (sent while TTS was initializing)
+            synchronized(this@FlutterTtsPlugin) {
+                ttsStatus = status
+                for (call in pendingMethodCalls) {
+                    call.run()
+                }
+                pendingMethodCalls.clear()
+            }
+
             if (status == TextToSpeech.SUCCESS) {
                 tts!!.setOnUtteranceProgressListener(utteranceProgressListener)
                 try {
@@ -229,15 +239,6 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
                     Log.e(tag, "getDefaultLocale: " + e.message)
                 } catch (e: IllegalArgumentException) {
                     Log.e(tag, "getDefaultLocale: " + e.message)
-                }
-
-                // Handle pending method calls (sent while TTS was initializing)
-                synchronized(this@FlutterTtsPlugin) {
-                    isTtsInitialized = true
-                    for (call in pendingMethodCalls) {
-                        call.run()
-                    }
-                    pendingMethodCalls.clear()
                 }
             } else {
                 Log.e(tag, "Failed to initialize TextToSpeech with status: $status")
@@ -247,7 +248,7 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
     override fun onMethodCall(call: MethodCall, result: Result) {
         // If TTS is still loading
         synchronized(this@FlutterTtsPlugin) {
-            if (!isTtsInitialized) {
+            if (ttsStatus == null) {
                 // Suspend method call until the TTS engine is ready
                 val suspendedCall = Runnable { onMethodCall(call, result) }
                 pendingMethodCalls.add(suspendedCall)
@@ -458,8 +459,8 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
 
     private fun setEngine(engine: String?, result: Result) {
         tts = TextToSpeech(context, onInitListener, engine)
-        isTtsInitialized = false
-        result.success(1)
+        ttsStatus = null
+        engineResult = result
     }
 
     private fun setLanguage(language: String?, result: Result) {
@@ -559,7 +560,7 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
     }
 
     private fun getDefaultEngine(result: Result) {
-        val defaultEngine: String = tts!!.defaultEngine
+        val defaultEngine: String? = tts!!.defaultEngine
         result.success(defaultEngine)
     }
 
@@ -601,8 +602,8 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
                 tts!!.speak(text, queueMode, bundle, uuid) == 0
             }
         } else {
-            isTtsInitialized = false
-            tts = TextToSpeech(context, onInitListener, googleTtsEngine)
+            ttsStatus = null
+            tts = TextToSpeech(context, onInitListener)
             false
         }
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:io' show Platform;
-import 'package:flutter/foundation.dart' show kIsWeb;
 
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_tts/flutter_tts.dart';
 
@@ -60,14 +60,6 @@ class _MyAppState extends State<MyApp> {
         ttsState = TtsState.playing;
       });
     });
-
-    if (isAndroid) {
-      flutterTts.setInitHandler(() {
-        setState(() {
-          print("TTS Initialized");
-        });
-      });
-    }
 
     flutterTts.setCompletionHandler(() {
       setState(() {

--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -330,8 +330,6 @@ class FlutterTts {
   static const MethodChannel _channel = const MethodChannel('flutter_tts');
 
   VoidCallback? startHandler;
-  VoidCallback? initHandler;
-  VoidCallback? _setEngineInitHandler;
   VoidCallback? completionHandler;
   VoidCallback? pauseHandler;
   VoidCallback? continueHandler;
@@ -454,10 +452,7 @@ class FlutterTts {
   /// [Future] which invokes the platform specific method for setEngine
   /// ***Android supported only***
   Future<dynamic> setEngine(String engine) async {
-    final initCompleter = Completer<void>();
-    _setEngineInitHandler = () => initCompleter.complete();
     await _channel.invokeMethod('setEngine', engine);
-    await initCompleter.future;
   }
 
   /// [Future] which invokes the platform specific method for setPitch
@@ -562,11 +557,6 @@ class FlutterTts {
     startHandler = callback;
   }
 
-  /// ***Android supported only***
-  void setInitHandler(VoidCallback callback) {
-    initHandler = callback;
-  }
-
   void setCompletionHandler(VoidCallback callback) {
     completionHandler = callback;
   }
@@ -600,15 +590,6 @@ class FlutterTts {
         }
         break;
 
-      /// ***Android supported only***
-      case "tts.init":
-        if (initHandler != null) {
-          initHandler!();
-        }
-        if (_setEngineInitHandler != null) {
-          _setEngineInitHandler!();
-        }
-        break;
       case "synth.onStart":
         if (startHandler != null) {
           startHandler!();


### PR DESCRIPTION
- Use `ttsStatus` instead of `isTtsInitialized`. When `TextToSpeech` initialization is completed, assign the result to `ttsStatus`. Even if `TextToSpeech` initialization fails, we can call `getEngines` to get the engine list to set a new engine.
- Remove `setInitHandler` and use `await setEngine` instead. On the Android side, we will call `engineResult` on the initialization callback.