### PR TITLE
Linter, deprecation and build system maintenance

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,14 +4,14 @@ group 'com.tundralabs.fluttertts'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.8.20'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -23,7 +23,7 @@ rootProject.allprojects {
     }
 }
 
-project.getTasks().withType(JavaCompile){
+project.getTasks().withType(JavaCompile).configureEach {
     options.compilerArgs.addAll(args)
 }
 
@@ -31,7 +31,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdk 34
     if (project.android.hasProperty("namespace")) {
         namespace 'com.tundralabs.fluttertts'
     }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -15,14 +15,14 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
     namespace 'com.tundralabs.example'
 
 
     defaultConfig {
         applicationId "com.tundralabs.flutterttsexample"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.2.0'
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip

--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 typedef void ErrorHandler(dynamic message);

--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -538,8 +538,10 @@ class FlutterTts {
     final normal = double.parse(validRange['normal'].toString());
     final max = double.parse(validRange['max'].toString());
     final platformStr = validRange['platform'].toString();
-    final platform = TextToSpeechPlatform.values
-        .firstWhere((e) => describeEnum(e) == platformStr);
+    //final platform = TextToSpeechPlatform.values
+    //    .firstWhere((e) => describeEnum(e) == platformStr);
+    final platform =
+        TextToSpeechPlatform.values.firstWhere((e) => e.name == platformStr);
 
     return SpeechRateValidRange(min, normal, max, platform);
   }

--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -537,8 +537,6 @@ class FlutterTts {
     final normal = double.parse(validRange['normal'].toString());
     final max = double.parse(validRange['max'].toString());
     final platformStr = validRange['platform'].toString();
-    //final platform = TextToSpeechPlatform.values
-    //    .firstWhere((e) => describeEnum(e) == platformStr);
     final platform =
         TextToSpeechPlatform.values.firstWhere((e) => e.name == platformStr);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,5 +29,5 @@ flutter:
         fileName: flutter_tts_web.dart
 
 environment:
-  sdk: '>=2.12.0-0 <4.0.0'
-  flutter: '>=1.22.0'
+  sdk: ">=2.15.0 <4.0.0"
+  flutter: ">=1.22.0"


### PR DESCRIPTION
Android:

- Upgrade to Kotlin 1.9.10
- Upgrade Gradle to 8.2.0
- Change compileSDK target to 34

Flutter:

- Fix describeEnum deprecation (requires Flutter SDK >=2.15.0)
- remove unnecessary foundation.dart include