### PR TITLE
fix: progressHandler not working on new devices & handlers not responding.

### DIFF
--- a/android/src/main/kotlin/com/tundralabs/fluttertts/FlutterTtsPlugin.kt
+++ b/android/src/main/kotlin/com/tundralabs/fluttertts/FlutterTtsPlugin.kt
@@ -95,9 +95,7 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
                         invokeMethod("speak.onStart", true)
                     }
                 }
-                if (Build.VERSION.SDK_INT < 26) {
-                    onProgress(utteranceId, 0, utterances[utteranceId]!!.length)
-                }
+                onProgress(utteranceId, 0, utterances[utteranceId]!!.length)
             }
 
             override fun onDone(utteranceId: String) {

--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -337,6 +337,10 @@ class FlutterTts {
   ErrorHandler? errorHandler;
 
   FlutterTts() {
+    setChannelMethodCallHandler();
+  }
+
+  void setChannelMethodCallHandler() {
     _channel.setMethodCallHandler(platformCallHandler);
   }
 


### PR DESCRIPTION
We just need to call setChannelMethodCallHandler after setting all of the handlers from project we're working in. 

We can also call this function on every set...Handlers method to make sure this is not required for the User Project.