### PR TITLE
Android: Fix 'Reply already submitted' bug during synthesizeToFile

### DIFF
--- a/android/src/main/kotlin/com/tundralabs/fluttertts/FlutterTtsPlugin.kt
+++ b/android/src/main/kotlin/com/tundralabs/fluttertts/FlutterTtsPlugin.kt
@@ -199,7 +199,10 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
 
     fun synthCompletion(success: Int) {
         synth = false
-        handler!!.post { synthResult?.success(success) }
+        handler!!.post {
+            synthResult?.success(success)
+            synthResult = null
+        }
     }
 
     private val onInitListener: TextToSpeech.OnInitListener =


### PR DESCRIPTION
This pull fixes "Reply already submitted" error following synthesizeToFile on Android. The fix has already been applied to speakCompletion in 3.8.4; this pull simply applies the same fix to synthCompletion.

Thank you!

