### PR TITLE
Ios: Fix exported audio have wrong sampleRate on ios 18

### DIFF
--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -200,7 +200,7 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
         if output == nil {
           do {
             if #available(iOS 17.0, *) {
-              guard let audioFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: Double(22050), channels: 1, interleaved: false) else {
+                guard let audioFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: pcmBuffer.format.sampleRate, channels: 1, interleaved: false) else {
                 NSLog("Error creating audio format for iOS 17+")
                 failed = true
                 return


### PR DESCRIPTION
Change sampleRate of audioFormat to flex with buffer instead of  22050Hz