### PR TITLE
speeding up iOS plugin initialization

### DIFF
--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -3,14 +3,12 @@ import UIKit
 import AVFoundation
 
 public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizerDelegate {
-  final var iosAudioCategoryKey = "iosAudioCategoryKey"
-  final var iosAudioCategoryOptionsKey = "iosAudioCategoryOptionsKey"
-  final var iosAudioModeKey = "iosAudioModeKey"
+  let iosAudioCategoryKey = "iosAudioCategoryKey"
+  let iosAudioCategoryOptionsKey = "iosAudioCategoryOptionsKey"
+  let iosAudioModeKey = "iosAudioModeKey"
 
   let synthesizer = AVSpeechSynthesizer()
-  var language: String = AVSpeechSynthesisVoice.currentLanguageCode()
   var rate: Float = AVSpeechUtteranceDefaultSpeechRate
-  var languages = Set<String>()
   var volume: Float = 1.0
   var pitch: Float = 1.0
   var voice: AVSpeechSynthesisVoice?
@@ -19,21 +17,21 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
   var autoStopSharedSession: Bool = true
   var speakResult: FlutterResult? = nil
   var synthResult: FlutterResult? = nil
+  
+  lazy var audioSession = AVAudioSession.sharedInstance()
+  lazy var language: String = {
+    AVSpeechSynthesisVoice.currentLanguageCode()
+  }()
+  lazy var languages: Set<String> = {
+    Set(AVSpeechSynthesisVoice.speechVoices().map(\.language))
+  }()
     
 
   var channel = FlutterMethodChannel()
-  lazy var audioSession = AVAudioSession.sharedInstance()
   init(channel: FlutterMethodChannel) {
     super.init()
     self.channel = channel
     synthesizer.delegate = self
-    setLanguages()
-  }
-
-  private func setLanguages() {
-    for voice in AVSpeechSynthesisVoice.speechVoices(){
-      self.languages.insert(voice.language)
-    }
   }
 
   public static func register(with registrar: FlutterPluginRegistrar) {


### PR DESCRIPTION
Importing `flutter_tts` can have a small penalty in the performance of the application startup in iOS:
during initialisation this plugin is performing some unnecessary operations that could be deferred later in the application lifecycle, when the plugin is actually needed.

The following screenshot is showing the Launches audits for an application I currently have in production. This tool shows that `flutter_tts` is responsible for ~200 ms spent during the app startup, when all the imported plugins are registered via the generated `registerWithRegistry(:)` method. This procedure is executed _on the main thread_ within the `AppDelegate.application(:didFinishLaunchingWithOptions:)` method.
![Screenshot](https://github.com/user-attachments/assets/dc2d665e-144e-4769-9e9c-b74a578926b0)

`flutter_tts` is spending some time in this phase eagerly initialising the `language` and `languages` fields:
```
var language: String = AVSpeechSynthesisVoice.currentLanguageCode()
var languages = Set<String>()
// ...
init(channel: FlutterMethodChannel) {
  super.init()
  self.channel = channel
  synthesizer.delegate = self
  setLanguages() 
}
```

Both these fields could be initialised lazily (just as the `audioSession` shared instance is already being initialised lazily), since they are not needed until later, when the plugin is eventually used by the application.

This PR aims at solving this small but noticeable performance impact of `flutter_tts` in iOS by simply initialising the `language` and `languages` fields lazily:
```
lazy var language: String = {
  AVSpeechSynthesisVoice.currentLanguageCode()
}()
lazy var languages: Set<String> = {
  Set(AVSpeechSynthesisVoice.speechVoices().map(\.language))
}()    

var channel = FlutterMethodChannel()
init(channel: FlutterMethodChannel) {
  super.init()
  self.channel = channel
  synthesizer.delegate = self
}
```