### PR TITLE
Replace deprecated exec_program with execute_process

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
+if(POLICY CMP0153)
+  cmake_policy(SET CMP0153 NEW)
+endif()
 set(PROJECT_NAME "flutter_tts")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
@@ -9,7 +12,9 @@ if(NOT NUGET_EXE)
 	message(FATAL_ERROR "Please install this executable, and run CMake again.")
 endif()
 
-exec_program(${NUGET_EXE}
+execute_process(
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/nuget.exe install -OutputDirectory ${CMAKE_CURRENT_SOURCE_DIR}/packages Microsoft.Windows.CppWinRT -Version 2.0.210312.4
+)
     ARGS install "Microsoft.Windows.CppWinRT" -Version 	2.0.210503.1 -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages)
 ################ NuGet install end ################
 


### PR DESCRIPTION
Replace deprecated exec_program with execute_process in Windows CMake build

Description
This pull request fixes a CMake policy warning (CMP0153) that appears during Windows builds by replacing the deprecated `exec_program()` call with the modern `execute_process()` command.

Motivation
When building a Flutter application for Windows that includes flutter_tts, the following warning appears: