### PR TITLE
Fix TTS reconnection behaviors

### DIFF
--- a/android/src/main/kotlin/com/tundralabs/fluttertts/FlutterTtsPlugin.kt
+++ b/android/src/main/kotlin/com/tundralabs/fluttertts/FlutterTtsPlugin.kt
@@ -54,6 +54,7 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
     private var isPaused: Boolean = false
     private var queueMode: Int = TextToSpeech.QUEUE_FLUSH
     private var ttsStatus: Int? = null
+    private var selectedEngine: String? = null
     private var engineResult: Result? = null
     private var parcelFileDescriptor: ParcelFileDescriptor? = null
     private var audioManager: AudioManager? = null
@@ -70,7 +71,7 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
         methodChannel!!.setMethodCallHandler(this)
         handler = Handler(Looper.getMainLooper())
         bundle = Bundle()
-        tts = TextToSpeech(context, firstTimeOnInitListener)
+        tts = TextToSpeech(context, onInitListenerWithoutCallback)
     }
 
     /** Android Plugin APIs  */
@@ -213,7 +214,7 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
         }
     }
 
-    private val onInitListener: TextToSpeech.OnInitListener =
+    private val onInitListenerWithCallback: TextToSpeech.OnInitListener =
         TextToSpeech.OnInitListener { status ->
             // Handle pending method calls (sent while TTS was initializing)
             synchronized(this@FlutterTtsPlugin) {
@@ -244,7 +245,7 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
             //engineResult = null
         }
 
-    private val firstTimeOnInitListener: TextToSpeech.OnInitListener =
+    private val onInitListenerWithoutCallback: TextToSpeech.OnInitListener =
         TextToSpeech.OnInitListener { status ->
             // Handle pending method calls (sent while TTS was initializing)
             synchronized(this@FlutterTtsPlugin) {
@@ -495,8 +496,9 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
 
     private fun setEngine(engine: String?, result: Result) {
         ttsStatus = null
+        selectedEngine = engine
         engineResult = result
-        tts = TextToSpeech(context, onInitListener, engine)
+        tts = TextToSpeech(context, onInitListenerWithCallback, engine)
     }
 
     private fun setLanguage(language: String?, result: Result) {
@@ -679,7 +681,7 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
             }
         } else {
             ttsStatus = null
-            tts = TextToSpeech(context, onInitListener)
+            tts = TextToSpeech(context, onInitListenerWithoutCallback, selectedEngine)
             false
         }
     }


### PR DESCRIPTION
Context: dlutton/flutter_tts#233 added a logic to address engine disconnection after a long running time.

Use OnInitListener that does not perform a plugin `result` callback, similar to when the plugin and the TTS engine are first initialized. Callbacks are only valid for the case of reinitialization using `setEngine` calls. Otherwise, the `engineResult` variable would remain unset and cause crashes when trying to access the value.

Instead of connecting to the system's default engine, store the name of and reconnect to the previously specified engine.