### PR TITLE
New Event Handler: voicesChanged

### DIFF
--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -596,6 +596,10 @@ class FlutterTts {
     errorHandler = handler;
   }
 
+  void setVoicesChangedHandler(VoidCallback handler) {
+    voicesChangedHandler = handler;
+  }
+
   /// Platform listeners
   Future<dynamic> platformCallHandler(MethodCall call) async {
     switch (call.method) {

--- a/lib/flutter_tts.dart
+++ b/lib/flutter_tts.dart
@@ -336,6 +336,7 @@ class FlutterTts {
   VoidCallback? cancelHandler;
   ProgressHandler? progressHandler;
   ErrorHandler? errorHandler;
+  VoidCallback? voicesChangedHandler;
 
   FlutterTts() {
     _channel.setMethodCallHandler(platformCallHandler);
@@ -653,6 +654,11 @@ class FlutterTts {
       case "synth.onError":
         if (errorHandler != null) {
           errorHandler!(call.arguments);
+        }
+        break;
+      case "synth.onVoicesChanged":
+        if (voicesChangedHandler != null) {
+          voicesChangedHandler!();
         }
         break;
       default:

--- a/lib/flutter_tts_web.dart
+++ b/lib/flutter_tts_web.dart
@@ -3,7 +3,6 @@ import 'dart:collection';
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 
-import 'package:logging/logging.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
@@ -12,7 +11,6 @@ import 'interop_types.dart';
 enum TtsState { playing, stopped, paused, continued }
 
 class FlutterTtsPlugin {
-  static final _log = Logger('AppRouteInformationParser');
   static const String platformChannel = "flutter_tts";
   static late MethodChannel channel;
   bool awaitSpeakCompletion = false;
@@ -207,17 +205,7 @@ class FlutterTtsPlugin {
   void _setRate(double rate) => utterance.rate = rate;
   void _setVolume(double volume) => utterance.volume = volume;
   void _setPitch(double pitch) => utterance.pitch = pitch;
-  void _setLanguage(String language) {
-    utterance.lang = language;
-    var tmpVoices = synth.getVoices().toDart;
-    var targetList = tmpVoices.where((voice) {
-      _log.fine('SpeechSynthesisVoice { lang: ${voice.lang}, name: ${voice.name}, isDefault: ${voice.isDefault}');
-      return voice.lang.startsWith(language) && voice.isDefault;
-    });
-    if (targetList.isNotEmpty) {
-      utterance.voice = targetList.first;
-    }
-  }
+  void _setLanguage(String language) => utterance.lang = language;
   void _setVoice(Map<String?, String?> voice) {
     var tmpVoices = synth.getVoices().toDart;
     var targetList = tmpVoices.where((e) {

--- a/lib/flutter_tts_web.dart
+++ b/lib/flutter_tts_web.dart
@@ -119,6 +119,10 @@ class FlutterTtsPlugin {
       };
       channel.invokeMethod("speak.onProgress", progressArgs);
     }.toJS;
+
+    synth.onVoicesChanged = (JSAny e) {
+      channel.invokeMethod("synth.onVoicesChanged", null);
+    }.toJS;
   }
 
   Future<dynamic> handleMethodCall(MethodCall call) async {

--- a/lib/flutter_tts_web.dart
+++ b/lib/flutter_tts_web.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 
+import 'package:logging/logging.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
@@ -11,6 +12,7 @@ import 'interop_types.dart';
 enum TtsState { playing, stopped, paused, continued }
 
 class FlutterTtsPlugin {
+  static final _log = Logger('AppRouteInformationParser');
   static const String platformChannel = "flutter_tts";
   static late MethodChannel channel;
   bool awaitSpeakCompletion = false;
@@ -205,7 +207,17 @@ class FlutterTtsPlugin {
   void _setRate(double rate) => utterance.rate = rate;
   void _setVolume(double volume) => utterance.volume = volume;
   void _setPitch(double pitch) => utterance.pitch = pitch;
-  void _setLanguage(String language) => utterance.lang = language;
+  void _setLanguage(String language) {
+    utterance.lang = language;
+    var tmpVoices = synth.getVoices().toDart;
+    var targetList = tmpVoices.where((voice) {
+      _log.fine('SpeechSynthesisVoice { lang: ${voice.lang}, name: ${voice.name}, isDefault: ${voice.isDefault}');
+      return voice.lang.startsWith(language) && voice.isDefault;
+    });
+    if (targetList.isNotEmpty) {
+      utterance.voice = targetList.first;
+    }
+  }
   void _setVoice(Map<String?, String?> voice) {
     var tmpVoices = synth.getVoices().toDart;
     var targetList = tmpVoices.where((e) {

--- a/lib/interop_types.dart
+++ b/lib/interop_types.dart
@@ -14,6 +14,9 @@ extension type SpeechSynthesis._(JSObject _) implements JSObject {
   external void resume();
 
   external void speak(SpeechSynthesisUtterance utterance);
+
+  @JS('onvoiceschanged')
+  external set onVoicesChanged(JSFunction listener);
 }
 
 @JS()

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_tts
 description: A flutter plugin for Text to Speech.  This plugin is supported on iOS, macOS, Android, Web, & Windows.
-version: 4.2.1
+version: 4.2.0
 homepage: https://github.com/dlutton/flutter_tts
 
 dependencies:
@@ -8,7 +8,6 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  logging: ^1.2.0
 
 flutter:
   plugin:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_tts
 description: A flutter plugin for Text to Speech.  This plugin is supported on iOS, macOS, Android, Web, & Windows.
-version: 4.2.0
+version: 4.2.1
 homepage: https://github.com/dlutton/flutter_tts
 
 dependencies:
@@ -8,6 +8,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
+  logging: ^1.2.0
 
 flutter:
   plugin:


### PR DESCRIPTION
The `voicesChanged` event handler is used to notify the Flutter app when the available TTS voices on the system have changed.

This event is triggered when:

- **New voices are installed** on the system
- **Voices are removed** from the system
- **Voice availability changes** (e.g., network voices become available/unavailable)
- **System language settings change** affecting available voices

When this event fires, it calls `synth.onVoicesChanged` on the Flutter side, allowing the app to:

- **Refresh the voice list** by calling `getVoices()` again
- **Update the UI** to show newly available voices
- **Handle voice unavailability** if a previously selected voice is no longer available
- **Adapt to system changes** without requiring app restart

This is particularly important for web TTS because voice availability can change dynamically based on network connectivity (for cloud voices) or system updates.