### PR TITLE
applied windows cmake fix from shrey113

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,55 +1,55 @@
 cmake_minimum_required(VERSION 3.14)
+
 if(POLICY CMP0153)
-  cmake_policy(SET CMP0153 NEW)
+    cmake_policy(SET CMP0153 NEW)
 endif()
+
 set(PROJECT_NAME "flutter_tts")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
-################ NuGet intall begin ################
 find_program(NUGET_EXE NAMES nuget)
 if(NOT NUGET_EXE)
-	message("NUGET.EXE not found.")
-	message(FATAL_ERROR "Please install this executable, and run CMake again.")
+    message(FATAL_ERROR "nuget.exe not found. Please install it.")
 endif()
 
 execute_process(
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/nuget.exe install -OutputDirectory ${CMAKE_CURRENT_SOURCE_DIR}/packages Microsoft.Windows.CppWinRT -Version 2.0.210312.4
+        COMMAND ${NUGET_EXE} install Microsoft.Windows.CppWinRT
+        -Version 2.0.210503.1
+        -ExcludeVersion
+        -OutputDirectory ${CMAKE_BINARY_DIR}/packages
 )
-    ARGS install "Microsoft.Windows.CppWinRT" -Version 	2.0.210503.1 -ExcludeVersion -OutputDirectory ${CMAKE_BINARY_DIR}/packages)
-################ NuGet install end ################
 
-# This value is used when generating builds using this plugin, so it must
-# not be changed
 set(PLUGIN_NAME "flutter_tts_plugin")
 
 add_library(${PLUGIN_NAME} SHARED
-  "flutter_tts_plugin.cpp"
+        "flutter_tts_plugin.cpp"
 )
+
 apply_standard_settings(${PLUGIN_NAME})
+
 set_target_properties(${PLUGIN_NAME} PROPERTIES
-CXX_VISIBILITY_PRESET hidden)
+        CXX_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN YES
+)
+
 target_compile_features(${PLUGIN_NAME} PUBLIC cxx_std_20)
 target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+
 target_include_directories(${PLUGIN_NAME} INTERFACE
-  "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
-
-if(MSVC)
-    target_compile_options(${PLUGIN_NAME} PRIVATE "/await")
-endif()
-
-# List of absolute paths to libraries that should be bundled with the plugin
-set(flutter_tts_bundled_libraries
-  ""
-  PARENT_SCOPE
-################ NuGet import begin ################
-set_target_properties(${PLUGIN_NAME} PROPERTIES VS_PROJECT_IMPORT
-  ${CMAKE_BINARY_DIR}/packages/Microsoft.Windows.CppWinRT/build/native/Microsoft.Windows.CppWinRT.props
+        "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )
 
 target_link_libraries(${PLUGIN_NAME} PRIVATE
-  ${CMAKE_BINARY_DIR}/packages/Microsoft.Windows.CppWinRT/build/native/Microsoft.Windows.CppWinRT.targets
+        flutter
+        flutter_wrapper_plugin
 )
-################ NuGet import end ################
 
+set_target_properties(${PLUGIN_NAME} PROPERTIES VS_PROJECT_IMPORT
+        "${CMAKE_BINARY_DIR}/packages/Microsoft.Windows.CppWinRT/build/native/Microsoft.Windows.CppWinRT.props"
 )
+
+target_link_libraries(${PLUGIN_NAME} PRIVATE
+        "${CMAKE_BINARY_DIR}/packages/Microsoft.Windows.CppWinRT/build/native/Microsoft.Windows.CppWinRT.targets"
+)
+
+set(flutter_tts_bundled_libraries "" PARENT_SCOPE)


### PR DESCRIPTION
applied this fix and it worked for me. other fixes offered in other issues raised didn't work for me. Im on flutter 3.32.8 & android studio otter 2

https://github.com/dlutton/flutter_tts/issues/615

 fvm flutter doctor -v
[!] Flutter (Channel stable, 3.32.8, on Microsoft Windows [Version 10.0.26100.7171], locale en-GB) [372ms]
    • Flutter version 3.32.8 on channel stable at C:\Users\Paul\fvm\versions\3.32.8
    ! Warning: `flutter` on your path resolves to C:\Users\Paul\fvm\versions\3.10.6\bin\flutter, which is not inside your current Flutter SDK checkout at C:\Users\Paul\fvm\versions\3.32.8. Consider adding C:\Users\Paul\fvm\versions\3.32.8\bin to the front of your path.
    ! Warning: `dart` on your path resolves to C:\Users\Paul\fvm\versions\3.10.6\bin\dart, which is not inside your current Flutter SDK checkout at C:\Users\Paul\fvm\versions\3.32.8. Consider adding C:\Users\Paul\fvm\versions\3.32.8\bin to the front of your path.
    • Upstream repository https://github.com/flutter/flutter.git
    • Framework revision edada7c56e (5 months ago), 2025-07-25 14:08:03 +0000
    • Engine revision ef0cd00091
    • Dart version 3.8.1
    • DevTools version 2.45.1
    • If those were intentional, you can disregard the above warnings; however it is recommended to use "git" directly to perform update checks and upgrades.

[√] Windows Version (11 Pro 64-bit, 24H2, 2009) [954ms]

[!] Android toolchain - develop for Android devices (Android SDK version 34.0.0) [2.1s]
    • Android SDK at C:\Users\Paul\AppData\Local\Android\sdk
    • Platform android-34, build-tools 34.0.0
    • Java binary at: C:\Program Files\Android\Android Studio\jbr\bin\java
      This is the JDK bundled with the latest Android Studio installation on this machine.
      To manually set the JDK path, use: `flutter config --jdk-dir="path/to/jdk"`.
    • Java version OpenJDK Runtime Environment (build 21.0.8+-14196175-b1038.72)
    ! Some Android licenses not accepted. To resolve this, run: flutter doctor --android-licenses

[√] Chrome - develop for the web [83ms]
    • Chrome at C:\Program Files\Google\Chrome\Application\chrome.exe

[√] Visual Studio - develop Windows apps (Visual Studio Community 2022 17.6.5) [82ms]
    • Visual Studio at C:\Program Files\Microsoft Visual Studio\2022\Community
    • Visual Studio Community 2022 version 17.6.33829.357
    • Windows 10 SDK version 10.0.22000.0

[√] Android Studio (version 2025.2.2) [13ms]
    • Android Studio at C:\Program Files\Android\Android Studio
    • Flutter plugin can be installed from:
       https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
       https://plugins.jetbrains.com/plugin/6351-dart
    • Java version OpenJDK Runtime Environment (build 21.0.8+-14196175-b1038.72)

[√] VS Code (version 1.86.2) [12ms]
    • VS Code at C:\Users\Paul\AppData\Local\Programs\Microsoft VS Code
    • Flutter extension version 3.102.0

[√] Connected device (3 available) [194ms]
    • Windows (desktop) • windows • windows-x64    • Microsoft Windows [Version 10.0.26100.7171]
    • Chrome (web)      • chrome  • web-javascript • Google Chrome 143.0.7499.170
    • Edge (web)        • edge    • web-javascript • Microsoft Edge 143.0.3650.96
    ! Device R5CN80VPHQK is not authorized.
      You might need to check your device for an authorization dialog.

[√] Network resources [566ms]
    • All expected network resources are available.

! Doctor found issues in 2 categories.