### PR TITLE
fix(ios): prevent crash when FlutterEngine is destroyed during background

### DIFF
--- a/ios/Classes/SwiftFlutterTtsPlugin.swift
+++ b/ios/Classes/SwiftFlutterTtsPlugin.swift
@@ -28,6 +28,21 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
     
 
   var channel = FlutterMethodChannel()
+  private var isEngineAttached = true
+
+  private func safeInvokeMethod(_ method: String, arguments: Any?) {
+    guard isEngineAttached else { return }
+    self.channel.invokeMethod(method, arguments: arguments)
+  }
+
+  deinit {
+    synthesizer.stopSpeaking(at: .immediate)
+    synthesizer.delegate = nil
+    speakResult = nil
+    synthResult = nil
+    isEngineAttached = false
+  }
+
   init(channel: FlutterMethodChannel) {
     super.init()
     self.channel = channel
@@ -431,6 +446,7 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
   }
 
   public func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
+    guard isEngineAttached else { return }
     if shouldDeactivateAndNotifyOthers(audioSession) && self.autoStopSharedSession {
       do {
         try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
@@ -446,23 +462,23 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
       self.synthResult!(1)
       self.synthResult = nil
     }
-    self.channel.invokeMethod("speak.onComplete", arguments: nil)
+    self.safeInvokeMethod("speak.onComplete", arguments: nil)
   }
 
   public func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didStart utterance: AVSpeechUtterance) {
-    self.channel.invokeMethod("speak.onStart", arguments: nil)
+    self.safeInvokeMethod("speak.onStart", arguments: nil)
   }
 
   public func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didPause utterance: AVSpeechUtterance) {
-    self.channel.invokeMethod("speak.onPause", arguments: nil)
+    self.safeInvokeMethod("speak.onPause", arguments: nil)
   }
 
   public func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didContinue utterance: AVSpeechUtterance) {
-    self.channel.invokeMethod("speak.onContinue", arguments: nil)
+    self.safeInvokeMethod("speak.onContinue", arguments: nil)
   }
 
   public func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didCancel utterance: AVSpeechUtterance) {
-    self.channel.invokeMethod("speak.onCancel", arguments: nil)
+    self.safeInvokeMethod("speak.onCancel", arguments: nil)
   }
 
   public func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, willSpeakRangeOfSpeechString characterRange: NSRange, utterance: AVSpeechUtterance) {
@@ -473,7 +489,7 @@ public class SwiftFlutterTtsPlugin: NSObject, FlutterPlugin, AVSpeechSynthesizer
       "end": String(characterRange.location + characterRange.length),
       "word": nsWord.substring(with: characterRange)
     ]
-    self.channel.invokeMethod("speak.onProgress", arguments: data)
+    self.safeInvokeMethod("speak.onProgress", arguments: data)
   }
 
 }


### PR DESCRIPTION
## Summary

Fixes a **FATAL crash** on iOS when `AVSpeechSynthesizerDelegate` callbacks fire after the `FlutterEngine` has been destroyed.

**Exception:** `NSInternalInconsistencyException: Sending a message before the FlutterEngine has been run.`
**Blame frame:** `@objc SwiftFlutterTtsPlugin.__ivar_destroyer`

## Root Cause

When the app enters the background, iOS may tear down TTS resources asynchronously. The `AVSpeechSynthesizerDelegate` methods (`didFinish`, `didStart`, `didCancel`, etc.) unconditionally call `self.channel.invokeMethod(...)` — but the `FlutterEngine` may no longer be running. This throws a fatal `NSInternalInconsistencyException`.

Three distinct crash paths observed in production:

| Trigger | iOS Stack Path |
|---------|---------------|
| TTS thread termination | `TTSSpeechServerInstance terminateSpeechThread` → `channel.invokeMethod` |
| Audio session notification | `AVAudioSession privatePostNotificationForType` → `channel.invokeMethod` |
| Object deallocation | `TTSSpeechServerInstance dealloc` → `AXSpeechManager .cxx_destruct` → `channel.invokeMethod` |

All crashes occur with `processState: BACKGROUND`.

## Fix

- Add `isEngineAttached` flag to track engine lifecycle state
- Add `safeInvokeMethod` helper that guards `channel.invokeMethod` calls behind the flag
- Add `deinit` to stop the synthesizer, nil the delegate, clear pending result callbacks, and set `isEngineAttached = false` — preventing delegate callbacks during deallocation
- Guard `didFinish` delegate body with early return when engine is detached (protects `speakResult`/`synthResult` closure calls too)
- Replace all 6 unguarded `channel.invokeMethod` calls with `safeInvokeMethod`

## Affected Devices (from production Crashlytics)

- iPhone X (iOS 16.7.12), iPhone 8 Plus (iOS 16.7.12), iPhone XS (iOS 15.4.1)
- Versions 3.2.5 through 5.2.1 of our app
- Regressed since v4.2.20

## Related Issues

Fixes #558
Fixes #595
Related: #318, flutter/flutter#104637