### PR TITLE
Fixed Android crash

### DIFF
--- a/android/src/main/kotlin/com/eyedeadevelopment/fluttertts/FlutterTtsPlugin.kt
+++ b/android/src/main/kotlin/com/eyedeadevelopment/fluttertts/FlutterTtsPlugin.kt
@@ -216,10 +216,11 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
 
     private val onInitListenerWithCallback: TextToSpeech.OnInitListener =
         TextToSpeech.OnInitListener { status ->
-            // Handle pending method calls (sent while TTS was initializing)
+            // Safely handle any pending method calls sent while TTS was initializing.
             synchronized(this@FlutterTtsPlugin) {
                 ttsStatus = status
-                for (call in pendingMethodCalls) {
+                // FIX 1: Iterate over a copy of the list to avoid ConcurrentModificationException.
+                for (call in pendingMethodCalls.toList()) {
                     call.run()
                 }
                 pendingMethodCalls.clear()
@@ -238,19 +239,28 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
                     Log.e(tag, "getDefaultLocale: " + e.message)
                 }
 
-                engineResult!!.success(1)
+                // FIX 2: Only reply once per request to avoid "Reply already submitted" crash.
+                if (engineResult != null) {
+                    engineResult!!.success(1)
+                    engineResult = null // Mark as handled to prevent double-reply.
+                }
             } else {
-                engineResult!!.error("TtsError","Failed to initialize TextToSpeech with status: $status", null)
+                // FIX 2: Only reply once per request to avoid "Reply already submitted" crash.
+                if (engineResult != null) {
+                    engineResult!!.error("TtsError","Failed to initialize TextToSpeech with status: $status", null)
+                    engineResult = null // Mark as handled to prevent double-reply.
+                }
             }
-            //engineResult = null
+            // No need to set engineResult = null here; already handled above.
         }
 
     private val onInitListenerWithoutCallback: TextToSpeech.OnInitListener =
         TextToSpeech.OnInitListener { status ->
-            // Handle pending method calls (sent while TTS was initializing)
+            // Safely handle any pending method calls sent while TTS was initializing.
             synchronized(this@FlutterTtsPlugin) {
                 ttsStatus = status
-                for (call in pendingMethodCalls) {
+                // FIX 1: Iterate over a copy of the list to avoid ConcurrentModificationException.
+                for (call in pendingMethodCalls.toList()) {
                     call.run()
                 }
                 pendingMethodCalls.clear()


### PR DESCRIPTION
FIX 1: Iterate over a copy of the list to avoid ConcurrentModificationException.
FIX 2: Only reply once per request to avoid "Reply already submitted" crash.


Exception java.util.ConcurrentModificationException:
at java.util.ArrayList$Itr.checkForComodification (ArrayList.java:1111)
at java.util.ArrayList$Itr.next (ArrayList.java:1064)
at com.tundralabs.fluttertts.FlutterTtsPlugin.onInitListener$lambda$3 (FlutterTtsPlugin.java:221)
at android.speech.tts.TextToSpeech.lambda$dispatchOnInit$0 (TextToSpeech.java:934)
at android.speech.tts.TextToSpeech.$r8$lambda$goj8UKjdOAM21kdYLRXRNDpSxxI (Unknown Source)
at android.speech.tts.TextToSpeech$$ExternalSyntheticLambda1.run (Unknown Source:4)
at android.speech.tts.TextToSpeech.dispatchOnInit (TextToSpeech.java:943)
at android.speech.tts.TextToSpeech.-$$Nest$mdispatchOnInit (Unknown Source)
at android.speech.tts.TextToSpeech$Connection$SetupConnectionAsyncTask.onPostExecute (TextToSpeech.java:2324)
at android.speech.tts.TextToSpeech$Connection$SetupConnectionAsyncTask.onPostExecute (TextToSpeech.java:2284)
at android.os.AsyncTask.finish (AsyncTask.java:771)
at android.os.AsyncTask.-$$Nest$mfinish (Unknown Source)
at android.os.AsyncTask$InternalHandler.handleMessage (AsyncTask.java:788)
at android.os.Handler.dispatchMessage (Handler.java:106)
at android.os.Looper.loopOnce (Looper.java:230)
at android.os.Looper.loop (Looper.java:319)
at android.app.ActivityThread.main (ActivityThread.java:8919)
at java.lang.reflect.Method.invoke
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:578)
at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)

Exception java.lang.IllegalStateException: Reply already submitted
at io.flutter.embedding.engine.dart.DartMessenger$Reply.reply (DartMessenger.java:431)
at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler$1.success (MethodChannel.java:272)
at com.tundralabs.fluttertts.FlutterTtsPlugin.onInitListener$lambda$3 (FlutterTtsPlugin.java:240)
at android.speech.tts.TextToSpeech.lambda$dispatchOnInit$0 (TextToSpeech.java:934)
at android.speech.tts.TextToSpeech.$r8$lambda$goj8UKjdOAM21kdYLRXRNDpSxxI (Unknown Source)
at android.speech.tts.TextToSpeech$$ExternalSyntheticLambda1.run (Unknown Source:4)
at android.speech.tts.TextToSpeech.dispatchOnInit (TextToSpeech.java:943)
at android.speech.tts.TextToSpeech.-$$Nest$mdispatchOnInit (Unknown Source)
at android.speech.tts.TextToSpeech$Connection$SetupConnectionAsyncTask.onPostExecute (TextToSpeech.java:2324)
at android.speech.tts.TextToSpeech$Connection$SetupConnectionAsyncTask.onPostExecute (TextToSpeech.java:2284)
at android.os.AsyncTask.finish (AsyncTask.java:771)
at android.os.AsyncTask.-$$Nest$mfinish (Unknown Source)
at android.os.AsyncTask$InternalHandler.handleMessage (AsyncTask.java:788)
at android.os.Handler.dispatchMessage (Handler.java:106)
at android.os.Looper.loopOnce (Looper.java:230)
at android.os.Looper.loop (Looper.java:319)
at android.app.ActivityThread.main (ActivityThread.java:8919)
at java.lang.reflect.Method.invoke
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:578)
at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)

